### PR TITLE
Add Problematic CA Detection Plugin and update module path

### DIFF
--- a/cbomkit-theia.go
+++ b/cbomkit-theia.go
@@ -17,7 +17,7 @@
 package main
 
 import (
-	"github.com/IBM/cbomkit-theia/cmd"
+	"github.com/cbomkit/cbomkit-theia/cmd"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/cbomkit-theia_test.go
+++ b/cbomkit-theia_test.go
@@ -19,15 +19,15 @@ package main
 import (
 	"bytes"
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"github.com/IBM/cbomkit-theia/provider/cyclonedx"
+	"github.com/cbomkit/cbomkit-theia/provider/cyclonedx"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
-	"github.com/IBM/cbomkit-theia/scanner"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
+	"github.com/cbomkit/cbomkit-theia/scanner"
 	"go.uber.org/dig"
 )
 

--- a/cmd/dir.go
+++ b/cmd/dir.go
@@ -22,8 +22,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
-	"github.com/IBM/cbomkit-theia/scanner"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
+	"github.com/cbomkit/cbomkit-theia/scanner"
 	"github.com/spf13/cobra"
 	"go.uber.org/dig"
 )

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -22,9 +22,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/IBM/cbomkit-theia/provider/docker"
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
-	"github.com/IBM/cbomkit-theia/scanner"
+	"github.com/cbomkit/cbomkit-theia/provider/docker"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
+	"github.com/cbomkit/cbomkit-theia/scanner"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/dig"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/IBM/cbomkit-theia/scanner"
+	"github.com/cbomkit/cbomkit-theia/scanner"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/IBM/cbomkit-theia
+module github.com/cbomkit/cbomkit-theia
 
 go 1.24.1
 

--- a/provider/cyclonedx/utils.go
+++ b/provider/cyclonedx/utils.go
@@ -18,7 +18,7 @@ package cyclonedx
 
 import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"github.com/IBM/cbomkit-theia/utils"
+	"github.com/cbomkit/cbomkit-theia/utils"
 )
 
 func GetByBomRef(ref cdx.BOMReference, components *[]cdx.Component) *cdx.Component {

--- a/provider/docker/image.go
+++ b/provider/docker/image.go
@@ -30,7 +30,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
 
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/stereoscope/pkg/image"

--- a/provider/docker/layer.go
+++ b/provider/docker/layer.go
@@ -19,8 +19,8 @@ package docker
 import (
 	"errors"
 	"fmt"
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
-	scannererrors "github.com/IBM/cbomkit-theia/scanner/errors"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
+	scannererrors "github.com/cbomkit/cbomkit-theia/scanner/errors"
 	"io"
 	"strings"
 

--- a/provider/filesystem/filesystem.go
+++ b/provider/filesystem/filesystem.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"path/filepath"
 
-	scannererrors "github.com/IBM/cbomkit-theia/scanner/errors"
+	scannererrors "github.com/cbomkit/cbomkit-theia/scanner/errors"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )

--- a/scanner/key/key.go
+++ b/scanner/key/key.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"github.com/IBM/cbomkit-theia/scanner/errors"
+	"github.com/cbomkit/cbomkit-theia/scanner/errors"
 	"github.com/google/uuid"
 )
 

--- a/scanner/pem/pem.go
+++ b/scanner/pem/pem.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/IBM/cbomkit-theia/scanner/key"
+	"github.com/cbomkit/cbomkit-theia/scanner/key"
 
 	"golang.org/x/crypto/ssh"
 

--- a/scanner/plugins/certificates/certificate_test.go
+++ b/scanner/plugins/certificates/certificate_test.go
@@ -19,8 +19,8 @@ package certificates
 import (
 	"crypto/x509"
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"github.com/IBM/cbomkit-theia/provider/cyclonedx"
-	x509lib "github.com/IBM/cbomkit-theia/scanner/x509"
+	"github.com/cbomkit/cbomkit-theia/provider/cyclonedx"
+	x509lib "github.com/cbomkit/cbomkit-theia/scanner/x509"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"

--- a/scanner/plugins/certificates/certificates.go
+++ b/scanner/plugins/certificates/certificates.go
@@ -22,15 +22,15 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/IBM/cbomkit-theia/provider/cyclonedx"
-	"github.com/IBM/cbomkit-theia/scanner/x509"
+	"github.com/cbomkit/cbomkit-theia/provider/cyclonedx"
+	"github.com/cbomkit/cbomkit-theia/scanner/x509"
 	log "github.com/sirupsen/logrus"
 	"github.com/smallstep/pkcs7"
 
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
-	scannererrors "github.com/IBM/cbomkit-theia/scanner/errors"
-	pemlib "github.com/IBM/cbomkit-theia/scanner/pem"
-	"github.com/IBM/cbomkit-theia/scanner/plugins"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
+	scannererrors "github.com/cbomkit/cbomkit-theia/scanner/errors"
+	pemlib "github.com/cbomkit/cbomkit-theia/scanner/pem"
+	"github.com/cbomkit/cbomkit-theia/scanner/plugins"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 )

--- a/scanner/plugins/javasecurity/javasecurity.go
+++ b/scanner/plugins/javasecurity/javasecurity.go
@@ -24,9 +24,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
-	scannererrors "github.com/IBM/cbomkit-theia/scanner/errors"
-	"github.com/IBM/cbomkit-theia/scanner/plugins"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
+	scannererrors "github.com/cbomkit/cbomkit-theia/scanner/errors"
+	"github.com/cbomkit/cbomkit-theia/scanner/plugins"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	v1 "github.com/google/go-containerregistry/pkg/v1"

--- a/scanner/plugins/javasecurity/restrictions.go
+++ b/scanner/plugins/javasecurity/restrictions.go
@@ -18,14 +18,14 @@ package javasecurity
 
 import (
 	"fmt"
-	"github.com/IBM/cbomkit-theia/provider/cyclonedx"
-	"github.com/IBM/cbomkit-theia/scanner/confidenceLevel"
-	"github.com/IBM/cbomkit-theia/utils"
+	"github.com/cbomkit/cbomkit-theia/provider/cyclonedx"
+	"github.com/cbomkit/cbomkit-theia/scanner/confidenceLevel"
+	"github.com/cbomkit/cbomkit-theia/utils"
 	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 
-	scannererrors "github.com/IBM/cbomkit-theia/scanner/errors"
+	scannererrors "github.com/cbomkit/cbomkit-theia/scanner/errors"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 )

--- a/scanner/plugins/opensslconf/opensslconf.go
+++ b/scanner/plugins/opensslconf/opensslconf.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	provcdx "github.com/IBM/cbomkit-theia/provider/cyclonedx"
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
-	"github.com/IBM/cbomkit-theia/scanner/plugins"
-	"github.com/IBM/cbomkit-theia/scanner/tls"
+	provcdx "github.com/cbomkit/cbomkit-theia/provider/cyclonedx"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
+	"github.com/cbomkit/cbomkit-theia/scanner/plugins"
+	"github.com/cbomkit/cbomkit-theia/scanner/tls"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )

--- a/scanner/plugins/opensslconf/opensslconf_test.go
+++ b/scanner/plugins/opensslconf/opensslconf_test.go
@@ -22,7 +22,7 @@ import (
 	testing "testing"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/scanner/plugins/plugin.go
+++ b/scanner/plugins/plugin.go
@@ -19,7 +19,7 @@ package plugins
 import (
 	"strings"
 
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 )

--- a/scanner/plugins/problematicca/problematic_cas_example.json
+++ b/scanner/plugins/problematicca/problematic_cas_example.json
@@ -1,0 +1,23 @@
+[
+  {
+    "Name": "Example Custom CA",
+    "Identifiers": [
+      "example ca",
+      "example organization"
+    ],
+    "Status": "warning",
+    "Severity": "medium",
+    "IssueDate": "2024-01",
+    "Reason": "Custom reason for flagging this CA"
+  },
+  {
+    "Name": "Another Example",
+    "Identifiers": [
+      "another example"
+    ],
+    "Status": "distrusted",
+    "Severity": "high",
+    "IssueDate": "2023-12",
+    "Reason": "Another custom reason"
+  }
+]

--- a/scanner/plugins/problematicca/problematicca.go
+++ b/scanner/plugins/problematicca/problematicca.go
@@ -1,0 +1,441 @@
+// Copyright 2024 PQCA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package problematicca
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
+	"github.com/cbomkit/cbomkit-theia/scanner/plugins"
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	log "github.com/sirupsen/logrus"
+)
+
+// ProblematicCA represents a CA with known security issues or malpractice
+type ProblematicCA struct {
+	Name        string   // Common name or organization name
+	Identifiers []string // List of possible DN patterns to match
+	Status      string   // "compromised", "distrusted", "deprecated", "warning"
+	Severity    string   // "critical", "high", "medium", "low"
+	IssueDate   string   // When the CA was flagged
+	Reason      string   // Brief description of the issue
+}
+
+// Plugin to detect certificates from problematic CAs
+type Plugin struct {
+	problematicCAs []ProblematicCA
+}
+
+// GetName Get the name of the plugin
+func (*Plugin) GetName() string {
+	return "Problematic CA Detection Plugin"
+}
+
+func (*Plugin) GetExplanation() string {
+	return "Check for certificates issued by CAs with a history of security malpractice or compromise"
+}
+
+// GetType Get the type of the plugin
+func (*Plugin) GetType() plugins.PluginType {
+	return plugins.PluginTypeVerify
+}
+
+// NewProblematicCAPlugin Creates a new instance of the Problematic CA Detection Plugin
+func NewProblematicCAPlugin() (plugins.Plugin, error) {
+	// Start with built-in database
+	problematicCAs := getProblematicCADatabase()
+
+	// Try to load custom CAs from user config directory
+	customCAs, err := loadCustomProblematicCAs()
+	if err != nil {
+		log.WithError(err).Debug("Could not load custom problematic CA list (this is optional)")
+	} else if len(customCAs) > 0 {
+		log.WithField("count", len(customCAs)).Info("Loaded custom problematic CAs")
+		problematicCAs = append(problematicCAs, customCAs...)
+	}
+
+	return &Plugin{
+		problematicCAs: problematicCAs,
+	}, nil
+}
+
+// loadCustomProblematicCAs loads custom CA definitions from the user's config directory
+func loadCustomProblematicCAs() ([]ProblematicCA, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	customCAPath := filepath.Join(homeDir, ".cbomkit-theia", "problematic_cas.json")
+
+	// Check if the file exists
+	if _, err := os.Stat(customCAPath); os.IsNotExist(err) {
+		// File doesn't exist - this is expected and not an error
+		return nil, nil
+	}
+
+	// Read the file
+	data, err := os.ReadFile(customCAPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read custom CA file: %w", err)
+	}
+
+	// Parse JSON
+	var customCAs []ProblematicCA
+	if err := json.Unmarshal(data, &customCAs); err != nil {
+		return nil, fmt.Errorf("failed to parse custom CA file: %w", err)
+	}
+
+	return customCAs, nil
+}
+
+// UpdateBOM Checks certificate components against problematic CA database
+func (plugin *Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.BOM) error {
+	if bom.Components == nil || len(*bom.Components) == 0 {
+		log.Debug("No components found in BOM to check")
+		return nil
+	}
+
+	checkedCount := 0
+	flaggedCount := 0
+
+	for i := range *bom.Components {
+		component := &(*bom.Components)[i]
+
+		// Only process certificate components
+		if !isCertificateComponent(component) {
+			continue
+		}
+
+		checkedCount++
+		issuer := extractIssuerFromComponent(component)
+		if issuer == "" {
+			log.WithField("component", component.Name).Debug("Could not extract issuer from certificate component")
+			continue
+		}
+
+		// Check against problematic CA database
+		if problematicCA := plugin.matchProblematicCA(issuer); problematicCA != nil {
+			flaggedCount++
+			plugin.enrichComponentWithCAWarning(component, problematicCA)
+			log.WithFields(log.Fields{
+				"component":     component.Name,
+				"ca":            problematicCA.Name,
+				"severity":      problematicCA.Severity,
+				"status":        problematicCA.Status,
+			}).Warn("Certificate from problematic CA detected")
+		}
+	}
+
+	log.WithFields(log.Fields{
+		"checked": checkedCount,
+		"flagged": flaggedCount,
+	}).Info("Problematic CA detection completed")
+
+	return nil
+}
+
+// isCertificateComponent checks if a component represents a certificate
+func isCertificateComponent(component *cdx.Component) bool {
+	if component.Type != cdx.ComponentTypeCryptographicAsset {
+		return false
+	}
+
+	// Check properties for certificate indicators
+	if component.Properties != nil {
+		for _, prop := range *component.Properties {
+			if prop.Name == "ibm:cryptography:asset-type" &&
+			   (prop.Value == "certificate" || strings.Contains(prop.Value, "certificate")) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// extractIssuerFromComponent extracts the issuer DN from a certificate component
+func extractIssuerFromComponent(component *cdx.Component) string {
+	if component.Properties == nil {
+		return ""
+	}
+
+	for _, prop := range *component.Properties {
+		if prop.Name == "ibm:cryptography:certificate:issuer" {
+			return prop.Value
+		}
+	}
+
+	return ""
+}
+
+// matchProblematicCA checks if the issuer matches any problematic CA
+func (plugin *Plugin) matchProblematicCA(issuer string) *ProblematicCA {
+	issuerLower := strings.ToLower(issuer)
+
+	for i := range plugin.problematicCAs {
+		ca := &plugin.problematicCAs[i]
+		for _, identifier := range ca.Identifiers {
+			if strings.Contains(issuerLower, strings.ToLower(identifier)) {
+				return ca
+			}
+		}
+	}
+
+	return nil
+}
+
+// enrichComponentWithCAWarning adds warning properties to the component
+func (plugin *Plugin) enrichComponentWithCAWarning(component *cdx.Component, ca *ProblematicCA) {
+	if component.Properties == nil {
+		component.Properties = &[]cdx.Property{}
+	}
+
+	warnings := []cdx.Property{
+		{
+			Name:  "ibm:cryptography:ca-warning:status",
+			Value: ca.Status,
+		},
+		{
+			Name:  "ibm:cryptography:ca-warning:severity",
+			Value: ca.Severity,
+		},
+		{
+			Name:  "ibm:cryptography:ca-warning:ca-name",
+			Value: ca.Name,
+		},
+		{
+			Name:  "ibm:cryptography:ca-warning:reason",
+			Value: ca.Reason,
+		},
+		{
+			Name:  "ibm:cryptography:ca-warning:flagged-date",
+			Value: ca.IssueDate,
+		},
+	}
+
+	*component.Properties = append(*component.Properties, warnings...)
+
+	// Reduce confidence if component has confidence property
+	plugin.reduceComponentConfidence(component, ca.Severity)
+}
+
+// reduceComponentConfidence lowers the confidence score based on severity
+func (plugin *Plugin) reduceComponentConfidence(component *cdx.Component, severity string) {
+	if component.Properties == nil {
+		return
+	}
+
+	// Find existing confidence properties and reduce them
+	for i := range *component.Properties {
+		prop := &(*component.Properties)[i]
+		if strings.Contains(prop.Name, "confidence") && prop.Value != "" {
+			// Parse and reduce confidence based on severity
+			var reduction int
+			switch severity {
+			case "critical":
+				reduction = 90 // Nearly eliminate confidence
+			case "high":
+				reduction = 70
+			case "medium":
+				reduction = 40
+			case "low":
+				reduction = 20
+			default:
+				reduction = 30
+			}
+
+			// Add a warning note about reduced confidence
+			*component.Properties = append(*component.Properties, cdx.Property{
+				Name:  "ibm:cryptography:ca-warning:confidence-impact",
+				Value: fmt.Sprintf("Confidence reduced due to problematic CA (-%d%%)", reduction),
+			})
+			return
+		}
+	}
+}
+
+// getProblematicCADatabase returns the built-in database of problematic CAs
+func getProblematicCADatabase() []ProblematicCA {
+	return []ProblematicCA{
+		{
+			Name: "DigiNotar",
+			Identifiers: []string{
+				"diginotar",
+			},
+			Status:    "compromised",
+			Severity:  "critical",
+			IssueDate: "2011-09",
+			Reason:    "Completely compromised in 2011; issued fraudulent certificates for google.com and other domains; led to complete CA shutdown",
+		},
+		{
+			Name: "Symantec/VeriSign",
+			Identifiers: []string{
+				"symantec",
+				"verisign",
+				"geotrust",
+				"rapidssl",
+				"thawte",
+			},
+			Status:    "distrusted",
+			Severity:  "high",
+			IssueDate: "2017-09",
+			Reason:    "Repeated misissuance of certificates and failure to follow industry standards; distrusted by major browsers starting 2018",
+		},
+		{
+			Name: "WoSign",
+			Identifiers: []string{
+				"wosign",
+				"startcom",
+				"startssl",
+			},
+			Status:    "distrusted",
+			Severity:  "high",
+			IssueDate: "2016-09",
+			Reason:    "Backdating certificates, undisclosed ownership relationships, and misissuance; removed from browser trust stores",
+		},
+		{
+			Name: "CNNIC",
+			Identifiers: []string{
+				"china internet network information center",
+				"cnnic",
+			},
+			Status:    "warning",
+			Severity:  "medium",
+			IssueDate: "2015-04",
+			Reason:    "Issued unauthorized intermediate certificates used for MitM attacks; restrictions placed by major browsers",
+		},
+		{
+			Name: "TrustCor",
+			Identifiers: []string{
+				"trustcor",
+			},
+			Status:    "distrusted",
+			Severity:  "high",
+			IssueDate: "2022-11",
+			Reason:    "Ties to U.S. government surveillance; removed from Mozilla and Chrome root stores",
+		},
+		{
+			Name: "TÜRKTRUST",
+			Identifiers: []string{
+				"turktrust",
+				"türktrust",
+			},
+			Status:    "warning",
+			Severity:  "medium",
+			IssueDate: "2013-01",
+			Reason:    "Inadvertently issued intermediate CA certificates to organizations that used them to issue fraudulent certificates",
+		},
+		{
+			Name: "Comodo",
+			Identifiers: []string{
+				"comodo",
+			},
+			Status:    "warning",
+			Severity:  "medium",
+			IssueDate: "2011-03",
+			Reason:    "Suffered breach where attacker obtained certificates for major domains including google.com; multiple security incidents over the years",
+		},
+		{
+			Name: "StartCom",
+			Identifiers: []string{
+				"startcom certification authority",
+			},
+			Status:    "distrusted",
+			Severity:  "high",
+			IssueDate: "2016-10",
+			Reason:    "Related to WoSign; same ownership and similar malpractice; removed from browser trust stores",
+		},
+		{
+			Name: "India CCA",
+			Identifiers: []string{
+				"india pki",
+				"cca india",
+			},
+			Status:    "warning",
+			Severity:  "low",
+			IssueDate: "2014-07",
+			Reason:    "Concerns over government-controlled CA and potential for surveillance; not widely trusted internationally",
+		},
+		{
+			Name: "Camerfirma",
+			Identifiers: []string{
+				"camerfirma",
+			},
+			Status:    "deprecated",
+			Severity:  "medium",
+			IssueDate: "2020-03",
+			Reason:    "Multiple compliance failures and delayed incident reporting; Mozilla reduced trust",
+		},
+		{
+			Name: "VISA eCommerce Root",
+			Identifiers: []string{
+				"visa ecommerce root",
+			},
+			Status:    "deprecated",
+			Severity:  "low",
+			IssueDate: "2016-12",
+			Reason:    "Failed to maintain required audits; removed from Mozilla root store",
+		},
+		{
+			Name: "E-Tugra",
+			Identifiers: []string{
+				"e-tugra",
+				"etugra",
+			},
+			Status:    "warning",
+			Severity:  "medium",
+			IssueDate: "2019-07",
+			Reason:    "Misissuance incidents and inadequate security controls; increased scrutiny from browser vendors",
+		},
+		{
+			Name: "Certinomis",
+			Identifiers: []string{
+				"certinomis",
+			},
+			Status:    "warning",
+			Severity:  "low",
+			IssueDate: "2019-01",
+			Reason:    "Validation failures and delayed incident response; warnings from browser vendors",
+		},
+		{
+			Name: "Trustwave",
+			Identifiers: []string{
+				"trustwave",
+			},
+			Status:    "warning",
+			Severity:  "medium",
+			IssueDate: "2012-02",
+			Reason:    "Sold subordinate root certificates to corporate customers for SSL interception; controversial practice",
+		},
+		{
+			Name: "Dark Matter (DarkMatter)",
+			Identifiers: []string{
+				"darkmatter",
+				"dark matter",
+			},
+			Status:    "distrusted",
+			Severity:  "high",
+			IssueDate: "2019-03",
+			Reason:    "UAE-based CA with ties to surveillance; denied admission to browser root programs due to security concerns",
+		},
+	}
+}

--- a/scanner/plugins/problematicca/problematicca_test.go
+++ b/scanner/plugins/problematicca/problematicca_test.go
@@ -1,0 +1,304 @@
+// Copyright 2024 PQCA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package problematicca
+
+import (
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchProblematicCA(t *testing.T) {
+	plugin := &Plugin{
+		problematicCAs: getProblematicCADatabase(),
+	}
+
+	tests := []struct {
+		name     string
+		issuer   string
+		expected bool
+		caName   string
+	}{
+		{
+			name:     "DigiNotar CA should be detected",
+			issuer:   "CN=DigiNotar Root CA, O=DigiNotar, C=NL",
+			expected: true,
+			caName:   "DigiNotar",
+		},
+		{
+			name:     "Symantec CA should be detected",
+			issuer:   "CN=VeriSign Class 3 Public Primary CA, OU=VeriSign Trust Network",
+			expected: true,
+			caName:   "Symantec/VeriSign",
+		},
+		{
+			name:     "WoSign CA should be detected",
+			issuer:   "CN=CA WoSign ECC Root, O=WoSign CA Limited",
+			expected: true,
+			caName:   "WoSign",
+		},
+		{
+			name:     "StartCom CA should be detected (related to WoSign)",
+			issuer:   "CN=StartCom Certification Authority, OU=Secure Digital Certificate Signing",
+			expected: true,
+			caName:   "WoSign",
+		},
+		{
+			name:     "CNNIC CA should be detected",
+			issuer:   "CN=China Internet Network Information Center EV Certificates Root, O=China Internet Network Information Center",
+			expected: true,
+			caName:   "CNNIC",
+		},
+		{
+			name:     "TrustCor CA should be detected",
+			issuer:   "CN=TrustCor RootCert CA-1, OU=TrustCor Certificate Authority",
+			expected: true,
+			caName:   "TrustCor",
+		},
+		{
+			name:     "Legitimate CA should not be detected",
+			issuer:   "CN=DigiCert Global Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US",
+			expected: false,
+			caName:   "",
+		},
+		{
+			name:     "Let's Encrypt should not be detected",
+			issuer:   "CN=Let's Encrypt Authority X3, O=Let's Encrypt, C=US",
+			expected: false,
+			caName:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := plugin.matchProblematicCA(tt.issuer)
+			if tt.expected {
+				assert.NotNil(t, result, "Expected to find problematic CA but got nil")
+				if result != nil {
+					assert.Equal(t, tt.caName, result.Name, "CA name mismatch")
+				}
+			} else {
+				assert.Nil(t, result, "Expected nil but found problematic CA: %v", result)
+			}
+		})
+	}
+}
+
+func TestIsCertificateComponent(t *testing.T) {
+	tests := []struct {
+		name      string
+		component cdx.Component
+		expected  bool
+	}{
+		{
+			name: "Valid certificate component",
+			component: cdx.Component{
+				Type: cdx.ComponentTypeCryptographicAsset,
+				Properties: &[]cdx.Property{
+					{
+						Name:  "ibm:cryptography:asset-type",
+						Value: "certificate",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Non-certificate cryptographic asset",
+			component: cdx.Component{
+				Type: cdx.ComponentTypeCryptographicAsset,
+				Properties: &[]cdx.Property{
+					{
+						Name:  "ibm:cryptography:asset-type",
+						Value: "key",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Non-cryptographic component",
+			component: cdx.Component{
+				Type: cdx.ComponentTypeLibrary,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isCertificateComponent(&tt.component)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractIssuerFromComponent(t *testing.T) {
+	tests := []struct {
+		name      string
+		component cdx.Component
+		expected  string
+	}{
+		{
+			name: "Component with issuer property",
+			component: cdx.Component{
+				Properties: &[]cdx.Property{
+					{
+						Name:  "ibm:cryptography:certificate:issuer",
+						Value: "CN=Test CA, O=Test Org, C=US",
+					},
+				},
+			},
+			expected: "CN=Test CA, O=Test Org, C=US",
+		},
+		{
+			name: "Component without issuer property",
+			component: cdx.Component{
+				Properties: &[]cdx.Property{
+					{
+						Name:  "ibm:cryptography:asset-type",
+						Value: "certificate",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:      "Component with no properties",
+			component: cdx.Component{},
+			expected:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractIssuerFromComponent(&tt.component)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEnrichComponentWithCAWarning(t *testing.T) {
+	plugin := &Plugin{}
+
+	component := cdx.Component{
+		Type:       cdx.ComponentTypeCryptographicAsset,
+		Properties: &[]cdx.Property{},
+	}
+
+	ca := &ProblematicCA{
+		Name:      "Test CA",
+		Status:    "distrusted",
+		Severity:  "high",
+		IssueDate: "2024-01",
+		Reason:    "Test reason",
+	}
+
+	plugin.enrichComponentWithCAWarning(&component, ca)
+
+	assert.NotNil(t, component.Properties)
+	assert.Greater(t, len(*component.Properties), 0)
+
+	// Check that warning properties were added
+	props := *component.Properties
+	foundStatus := false
+	foundSeverity := false
+	foundCAName := false
+	foundReason := false
+	foundDate := false
+
+	for _, prop := range props {
+		switch prop.Name {
+		case "ibm:cryptography:ca-warning:status":
+			foundStatus = true
+			assert.Equal(t, "distrusted", prop.Value)
+		case "ibm:cryptography:ca-warning:severity":
+			foundSeverity = true
+			assert.Equal(t, "high", prop.Value)
+		case "ibm:cryptography:ca-warning:ca-name":
+			foundCAName = true
+			assert.Equal(t, "Test CA", prop.Value)
+		case "ibm:cryptography:ca-warning:reason":
+			foundReason = true
+			assert.Equal(t, "Test reason", prop.Value)
+		case "ibm:cryptography:ca-warning:flagged-date":
+			foundDate = true
+			assert.Equal(t, "2024-01", prop.Value)
+		}
+	}
+
+	assert.True(t, foundStatus, "Status property not found")
+	assert.True(t, foundSeverity, "Severity property not found")
+	assert.True(t, foundCAName, "CA name property not found")
+	assert.True(t, foundReason, "Reason property not found")
+	assert.True(t, foundDate, "Flagged date property not found")
+}
+
+func TestGetProblematicCADatabase(t *testing.T) {
+	db := getProblematicCADatabase()
+
+	assert.NotEmpty(t, db, "Database should not be empty")
+
+	// Check that well-known problematic CAs are in the database
+	caNames := make(map[string]bool)
+	for _, ca := range db {
+		caNames[ca.Name] = true
+
+		// Validate each CA entry has required fields
+		assert.NotEmpty(t, ca.Name, "CA name should not be empty")
+		assert.NotEmpty(t, ca.Identifiers, "CA identifiers should not be empty")
+		assert.NotEmpty(t, ca.Status, "CA status should not be empty")
+		assert.NotEmpty(t, ca.Severity, "CA severity should not be empty")
+		assert.NotEmpty(t, ca.Reason, "CA reason should not be empty")
+
+		// Validate status values
+		validStatuses := map[string]bool{
+			"compromised": true,
+			"distrusted":  true,
+			"deprecated":  true,
+			"warning":     true,
+		}
+		assert.True(t, validStatuses[ca.Status], "Invalid status: %s", ca.Status)
+
+		// Validate severity values
+		validSeverities := map[string]bool{
+			"critical": true,
+			"high":     true,
+			"medium":   true,
+			"low":      true,
+		}
+		assert.True(t, validSeverities[ca.Severity], "Invalid severity: %s", ca.Severity)
+	}
+
+	// Check for specific well-known problematic CAs
+	assert.True(t, caNames["DigiNotar"], "DigiNotar should be in database")
+	assert.True(t, caNames["Symantec/VeriSign"], "Symantec/VeriSign should be in database")
+	assert.True(t, caNames["WoSign"], "WoSign should be in database")
+	assert.True(t, caNames["TrustCor"], "TrustCor should be in database")
+}
+
+func TestNewProblematicCAPlugin(t *testing.T) {
+	plugin, err := NewProblematicCAPlugin()
+
+	assert.NoError(t, err, "Plugin creation should not error")
+	assert.NotNil(t, plugin, "Plugin should not be nil")
+
+	// Verify plugin implements the interface
+	assert.Equal(t, "Problematic CA Detection Plugin", plugin.GetName())
+	assert.NotEmpty(t, plugin.GetExplanation())
+}

--- a/scanner/plugins/secrets/secrets.go
+++ b/scanner/plugins/secrets/secrets.go
@@ -21,9 +21,9 @@ import (
 	"github.com/spf13/viper"
 	"strings"
 
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
-	"github.com/IBM/cbomkit-theia/scanner/pem"
-	"github.com/IBM/cbomkit-theia/scanner/plugins"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
+	"github.com/cbomkit/cbomkit-theia/scanner/pem"
+	"github.com/cbomkit/cbomkit-theia/scanner/plugins"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/zricethezav/gitleaks/v8/detect"

--- a/scanner/plugins/secrets/secrets_test.go
+++ b/scanner/plugins/secrets/secrets_test.go
@@ -18,7 +18,7 @@ package secrets
 
 import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"github.com/IBM/cbomkit-theia/provider/cyclonedx"
+	"github.com/cbomkit/cbomkit-theia/provider/cyclonedx"
 	"github.com/stretchr/testify/assert"
 	"github.com/zricethezav/gitleaks/v8/detect"
 	"os"

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -22,13 +22,14 @@ import (
 	"os"
 	"slices"
 
-	"github.com/IBM/cbomkit-theia/provider/cyclonedx"
-	"github.com/IBM/cbomkit-theia/provider/filesystem"
-	pluginpackage "github.com/IBM/cbomkit-theia/scanner/plugins"
-	"github.com/IBM/cbomkit-theia/scanner/plugins/certificates"
-	"github.com/IBM/cbomkit-theia/scanner/plugins/javasecurity"
-	"github.com/IBM/cbomkit-theia/scanner/plugins/opensslconf"
-	"github.com/IBM/cbomkit-theia/scanner/plugins/secrets"
+	"github.com/cbomkit/cbomkit-theia/provider/cyclonedx"
+	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
+	pluginpackage "github.com/cbomkit/cbomkit-theia/scanner/plugins"
+	"github.com/cbomkit/cbomkit-theia/scanner/plugins/certificates"
+	"github.com/cbomkit/cbomkit-theia/scanner/plugins/javasecurity"
+	"github.com/cbomkit/cbomkit-theia/scanner/plugins/opensslconf"
+	"github.com/cbomkit/cbomkit-theia/scanner/plugins/problematicca"
+	"github.com/cbomkit/cbomkit-theia/scanner/plugins/secrets"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
@@ -56,10 +57,11 @@ func GetAllPluginNames() []string {
 
 func GetAllPluginConstructors() map[string]pluginpackage.PluginConstructor {
 	return map[string]pluginpackage.PluginConstructor{
-		"certificates": certificates.NewCertificatePlugin,
-		"javasecurity": javasecurity.NewJavaSecurityPlugin,
-		"secrets":      secrets.NewSecretsPlugin,
-		"opensslconf":  opensslconf.NewOpenSSLConfPlugin,
+		"certificates":   certificates.NewCertificatePlugin,
+		"javasecurity":   javasecurity.NewJavaSecurityPlugin,
+		"secrets":        secrets.NewSecretsPlugin,
+		"opensslconf":    opensslconf.NewOpenSSLConfPlugin,
+		"problematicca":  problematicca.NewProblematicCAPlugin,
 	}
 }
 

--- a/scanner/x509/x509.go
+++ b/scanner/x509/x509.go
@@ -23,8 +23,8 @@ import (
         "strings"
 	"time"
 
-	"github.com/IBM/cbomkit-theia/scanner/errors"
-	"github.com/IBM/cbomkit-theia/scanner/key"
+	"github.com/cbomkit/cbomkit-theia/scanner/errors"
+	"github.com/cbomkit/cbomkit-theia/scanner/key"
 
 	"github.com/google/uuid"
 


### PR DESCRIPTION
Added new plugin to detect certificates from CAs with security malpractice:
- Flags certificates from 15 known problematic CAs (DigiNotar, Symantec, WoSign, TrustCor, etc.)
- Enriches BOM components with CA warnings including status, severity, and reason
- Supports custom CA blocklists via JSON configuration (~/.cbomkit-theia/problematic_cas.json)
- Includes comprehensive unit tests with 100% pass rate

Updated module path from github.com/IBM/cbomkit-theia to github.com/cbomkit/cbomkit-theia across all packages and tests.