### PR TITLE
fix(scanner): prevent oom crashes by capping file read size

### DIFF
--- a/scanner/plugins/certificates/certificates.go
+++ b/scanner/plugins/certificates/certificates.go
@@ -18,6 +18,7 @@ package certificates
 
 import (
 	"encoding/pem"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,22 +71,26 @@ func (certificatesPlugin *Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.B
 
 	err = fs.WalkDir(
 		func(path string) (err error) {
-			readCloser, err := fs.Open(path)
-			if err != nil {
-				return nil
-			}
-			raw, err := filesystem.ReadAllAndClose(readCloser)
-			if err != nil {
-				return nil
-			}
-
 			// Skip large files
 			maxFileSize := viper.GetInt64("keys.max_file_size")
 			if maxFileSize <= 0 {
 				maxFileSize = 1024 * 1024 // Default to 1MB
 			}
+
+			readCloser, err := fs.Open(path)
+			if err != nil {
+				return nil
+			}
+			defer readCloser.Close()
+
+			limitReader := io.LimitReader(readCloser, maxFileSize+1)
+			raw, err := io.ReadAll(limitReader)
+			if err != nil {
+				return nil
+			}
+
 			if int64(len(raw)) > maxFileSize {
-				log.Warnf("Skipping large file: %s (size: %d bytes)", path, len(raw))
+				log.Warnf("Skipping large file: %s (exceeds limit of %d bytes)", path, maxFileSize)
 				return nil
 			}
 

--- a/scanner/plugins/secrets/secrets.go
+++ b/scanner/plugins/secrets/secrets.go
@@ -17,6 +17,7 @@
 package secrets
 
 import (
+	"io"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"strings"
@@ -59,7 +60,7 @@ func (*Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.BOM) error {
 		return err
 	}
 	// Detect findings
-	findings := make([]findingWithMetadata, 0)
+	components := make([]cdx.Component, 0)
 	if err := fs.WalkDir(func(path string) error {
 		// Skip large files
 		maxFileSize := viper.GetInt64("keys.max_file_size")
@@ -71,8 +72,10 @@ func (*Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.BOM) error {
 		if err != nil {
 			return nil // skip and continue
 		}
+		defer readCloser.Close()
 
-		content, err := filesystem.ReadAllAndClose(readCloser)
+		limitReader := io.LimitReader(readCloser, maxFileSize+1)
+		content, err := io.ReadAll(limitReader)
 		if err != nil {
 			log.WithField("path", path).Warn("Unable to read file")
 			return nil
@@ -80,19 +83,27 @@ func (*Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.BOM) error {
 
 		// Skip large files
 		if int64(len(content)) > maxFileSize {
-			log.Warnf("Skipping large file: %s (size: %d bytes)", path, len(content))
+			log.Warnf("Skipping large file: %s (exceeds limit of %d bytes)", path, maxFileSize)
 			return nil
 		}
 
 		fragment := detect.Fragment{Raw: string(content), FilePath: path}
 		for _, finding := range detector.Detect(fragment) {
-			findings = append(findings, findingWithMetadata{
+			findingMeta := findingWithMetadata{
 				Finding: finding,
 				raw:     content,
-			})
+			}
 			log.WithFields(log.Fields{
 				"type": finding.RuleID, "file": finding.File,
 			}).Info("Secret detected")
+
+			// Create CDX Components
+			currentComponents, err := findingMeta.getComponents()
+			if err != nil {
+				log.WithError(err).Warn("Could not add secret finding to BOM component")
+				continue
+			}
+			components = append(components, currentComponents...)
 		}
 		return nil
 	}); err != nil {
@@ -100,21 +111,11 @@ func (*Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.BOM) error {
 		return err
 	}
 
-	if len(findings) == 0 {
+	if len(components) == 0 {
 		log.Info("No secrets found.")
 		return nil
 	}
 
-	// Create CDX Components
-	components := make([]cdx.Component, 0)
-	for _, finding := range findings {
-		currentComponents, err := finding.getComponents()
-		if err != nil {
-			log.WithError(err).Warn("Could not add secret finding to BOM component")
-			continue
-		}
-		components = append(components, currentComponents...)
-	}
 	// Write  bom
 	*bom.Components = append(*bom.Components, components...)
 	return nil


### PR DESCRIPTION
### Summary
This PR should fix a Out-Of-Memory problem in the scanner plugins by enforcing a strict memory cap during file reads, preventing unbounded memory allocations when analyzing massive files.

### Motivation
Previously, the certificates and secrets plugins utilized unbounded read operations to load files entirely into RAM before parsing. When the scanner encountered large files (e.g. multi-gigabyte Database files) this caused big memory spikes. In our deployment, scanner was running in K8s environment with limited memory usage to scan other container images, this resulted in abrupt crashes of the entire container the scanner was running in.

This was tested with the following image: `https://hub.docker.com/r/tenable/securitycenter-install`. While the previous code spikes on memory usage near 6 GiB while after the fix it spikes at around 500 MiB.  

### Features

- **Bounded Memory Allocation**: Caps all file read operations to a maximum threshold using io.LimitReader.

- **Keeping the configurable Limits and Default Limits**

### Files Modified
provider/plugins/certificates/
└── certificates.go        # Replaced ReadAllAndClose with LimitReader + defer
provider/plugins/secrets/
└── secrets.go             # Replaced unbounded ReadAll with LimitReader + defer

### Testing
```
$ go test ./scanner/plugins/certificates/... -v
=== RUN   TestIssue140_CombinedPEMFile
=== RUN   TestIssue140_CombinedPEMFile/parsePEMCertificatesFromPath_finds_cert_in_combined_file
=== RUN   TestIssue140_CombinedPEMFile/parsePEMCertificatesFromPath_returns_nil_for_non-PEM_file
=== RUN   TestIssue140_CombinedPEMFile/parsePEMCertificatesFromPath_returns_nil_for_PEM_with_only_keys
--- PASS: TestIssue140_CombinedPEMFile (0.00s)
    --- PASS: TestIssue140_CombinedPEMFile/parsePEMCertificatesFromPath_finds_cert_in_combined_file (0.00s)
    --- PASS: TestIssue140_CombinedPEMFile/parsePEMCertificatesFromPath_returns_nil_for_non-PEM_file (0.00s)
    --- PASS: TestIssue140_CombinedPEMFile/parsePEMCertificatesFromPath_returns_nil_for_PEM_with_only_keys (0.00s)
=== RUN   TestIssue56
=== RUN   TestIssue56/Issue_56
_redacted_
--- PASS: TestIssue56 (0.00s)
    --- PASS: TestIssue56/Issue_56 (0.00s)
PASS
ok      github.com/cbomkit/cbomkit-theia/scanner/plugins/certificates   0.007s

$ go test ./scanner/plugins/secrets/... -v
=== RUN   TestPrivateKey
_redacted_
--- PASS: TestPrivateKey (0.04s)
PASS
ok      github.com/cbomkit/cbomkit-theia/scanner/plugins/secrets        0.049s
```

### Breaking Changes
None.
