### PR TITLE
Feat: Set log level via cmd line, config or env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ Available Commands:
   image       Analyze cryptographic assets in a container image
 
 Flags:
-  -b, --bom string        BOM file to be verified and enriched
-      --config string     config file (default is $HOME/.cbomkit-theia.yaml)
-  -h, --help              help for cbomkit-theia
-      --ignore strings    file path patterns to ignore during scanning (glob syntax, e.g. 'testdata/,*.tmp')
-  -p, --plugins strings   list of plugins to use (default [certificates,javasecurity,secrets,opensslconf,keys,vex])
-      --schema string     BOM schema to validate the given BOM (default "provider/cyclonedx/bom-1.6.schema.json")
+  -b, --bom string          BOM file to be verified and enriched
+      --config string       config file (default is $HOME/.cbomkit-theia.yaml)
+      --docker-host string  Docker daemon socket (default "unix:///var/run/docker.sock")
+  -h, --help                help for cbomkit-theia
+      --ignore strings      file path patterns to ignore during scanning (glob syntax, e.g. 'testdata/,*.tmp')
+      --log-level string    log level (trace, debug, info, warn, error, fatal, panic) (default "info")
+  -p, --plugins strings     list of plugins to use (default [certificates,javasecurity,secrets,opensslconf,keys,vex])
+      --schema string       BOM schema to validate the given BOM (default "provider/cyclonedx/bom-1.6.schema.json")
 
 Use "cbomkit-theia [command] --help" for more information about a command.
 ```

--- a/cbomkit-theia.go
+++ b/cbomkit-theia.go
@@ -18,12 +18,9 @@ package main
 
 import (
 	"github.com/cbomkit/cbomkit-theia/cmd"
-	log "github.com/sirupsen/logrus"
 )
 
 // Function used to set logging and start cobra
 func main() {
-	// Create a LevelVar and set it to DEBUG
-	log.SetLevel(log.InfoLevel)
 	cmd.Execute()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cbomkit/cbomkit-theia/scanner"
 	log "github.com/sirupsen/logrus"
@@ -31,6 +32,7 @@ var cfgFile string
 var bomFilePath string
 var activatedPlugins []string
 var ignorePatterns []string
+var logLevel string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -126,6 +128,16 @@ func init() {
 		log.Error(err)
 		return
 	}
+
+	// add log level flag
+	rootCmd.
+		PersistentFlags().
+		StringVar(&logLevel, "log-level", "info", "log level (trace, debug, info, warn, error, fatal, panic)")
+	err = viper.BindPFlag("log_level", rootCmd.PersistentFlags().Lookup("log-level"))
+	if err != nil {
+		log.Error(err)
+		return
+	}
 }
 
 const configName = "config"
@@ -150,6 +162,7 @@ func initConfig() {
 	viper.SetDefault("docker_host", "unix:///var/run/docker.sock")
 	viper.SetDefault("plugins", allPlugins)
 	viper.SetDefault("ignore", []string{})
+	viper.SetDefault("log_level", "info")
 
 	// Find and read the config file
 	if err := viper.ReadInConfig(); err != nil { // Handle errors reading the config file
@@ -199,8 +212,24 @@ func initConfig() {
 		log.Error("Error in configuring cbomkit-theia: ", err)
 		return
 	}
-	// read in environment variables that match
+	// Set environment variable prefix and read in environment variables that match
+	viper.SetEnvPrefix("THEIA")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
+
+	// Set log level from config/flag/env
+	SetLogLevel(viper.GetString("log_level"))
+}
+
+// SetLogLevel sets the logrus log level based on the provided string
+func SetLogLevel(levelStr string) {
+	level, err := log.ParseLevel(levelStr)
+	if err != nil {
+		log.WithField("level", levelStr).WithError(err).Warn("Invalid log level, defaulting to 'info'")
+		log.SetLevel(log.InfoLevel)
+		return
+	}
+	log.SetLevel(level)
 }
 
 func getPluginExplanations() string {

--- a/provider/cyclonedx/bom.go
+++ b/provider/cyclonedx/bom.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"io"
-	"log/slog"
 	"slices"
 	"time"
 )
@@ -76,7 +76,7 @@ func ParseBOM(bomReader io.Reader) (*cdx.BOM, error) {
 		return new(cdx.BOM), err
 	}
 	// Decode BOM from JSON
-	slog.Debug("Decoding BOM from JSON to GO object")
+	log.Debug("Decoding BOM from JSON to GO object")
 	bom := new(cdx.BOM)
 	decoder := cdx.NewBOMDecoder(bytes.NewReader(bomBytes), cdx.BOMFileFormatJSON)
 	err = decoder.Decode(bom)

--- a/provider/docker/image.go
+++ b/provider/docker/image.go
@@ -25,7 +25,6 @@ import (
 	"github.com/moby/go-archive/compression"
 	log "github.com/sirupsen/logrus"
 	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -96,13 +95,13 @@ func BuildImage(dockerfilePath string) (image ActiveImage, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	slog.Info("Connecting to Docker Client using API version negotiaton", "client", os.Getenv("DOCKER_HOST"))
+	log.WithField("client", os.Getenv("DOCKER_HOST")).Info("Connecting to Docker Client using API version negotiation")
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return ActiveImage{}, err
 	}
 
-	slog.Debug("Tarring directory with Dockerfile", "path", dockerfilePath)
+	log.WithField("path", dockerfilePath).Debug("Tarring directory with Dockerfile")
 	tar, err := archive.Tar(filepath.Dir(dockerfilePath), compression.Gzip)
 	if err != nil {
 		return ActiveImage{}, err
@@ -114,7 +113,7 @@ func BuildImage(dockerfilePath string) (image ActiveImage, err error) {
 		SuppressOutput: true,
 	}
 
-	slog.Info("Building Docker image", "path", dockerfilePath)
+	log.WithField("path", dockerfilePath).Info("Building Docker image")
 	imageBuildResponse, err := cli.ImageBuild(ctx, tar, buildOptions)
 	if err != nil {
 		return ActiveImage{}, err
@@ -141,7 +140,7 @@ func BuildImage(dockerfilePath string) (image ActiveImage, err error) {
 
 	imageID := getImgIDWithoutDigest(responseStruct.DigestID)
 
-	slog.Info("Docker image built successfully! ImageID", "id", imageID)
+	log.WithField("id", imageID).Info("Docker image built successfully!")
 
 	stereoscopeImage, err := stereoscope.GetImage(ctx, imageID)
 	if err != nil {


### PR DESCRIPTION
1. Added Runtime Log Level Configuration
- Added --log-level CLI flag (hyphen for user interface)
- Supports three configuration methods:
  - CLI flag: --log-level debug
  - Config file: log_level: debug in ~/.cbomkit-theia/config.yaml
  - Environment variable: THEIA_LOG_LEVEL=debug
- Added viper.SetEnvPrefix("THEIA") for namespaced environment variables
- Added viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_")) for nested keys
- Removed hardcoded log level from main function, default remains info
2. Standardized Logging Library
3. Updated Documentation
