### PR TITLE
cbomkit-theia crashes when it encounters raw binary DER file

### DIFF
--- a/scanner/plugins/certificates/certificates.go
+++ b/scanner/plugins/certificates/certificates.go
@@ -189,11 +189,14 @@ func parseX509CertFromPath(raw []byte, path string) ([]*x509.CertificateWithMeta
 	return certs, nil
 }
 
-// Parse X.509 certificates from a PKCS7 file (base64 PEM format)
+// Parse X.509 certificates from a PKCS7 file (PEM or raw DER format)
 func parsePKCS7FromPath(raw []byte, path string) ([]*x509.CertificateWithMetadata, error) {
-	block, _ := pem.Decode(raw)
+	der := raw
+	if block, _ := pem.Decode(raw); block != nil {
+		der = block.Bytes
+	}
 
-	pkcs7Object, err := pkcs7.Parse(block.Bytes)
+	pkcs7Object, err := pkcs7.Parse(der)
 	if err != nil || pkcs7Object == nil {
 		return make([]*x509.CertificateWithMetadata, 0), err
 	}


### PR DESCRIPTION
The scanner crashes when it encounters binary DER and not a PEM wrapped file.The fix is a Nil check.

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x104e8351c]

goroutine 1 [running]:
github.com/IBM/cbomkit-theia/scanner/plugins/certificates.parsePKCS7FromPath({0x1400ccdd800?, 0x1400cbf2b50?, 0x38?}, {0x1400cd2cc09, 0x49})
	/Users/dubera9/cbomkit/cbomkit-theia/scanner/plugins/certificates/certificates.go:175 +0x2c
github.com/IBM/cbomkit-theia/scanner/plugins/certificates.(*Plugin).UpdateBOM.func1({0x1400cd2cc09, 0x49})
	/Users/dubera9/cbomkit/cbomkit-theia/scanner/plugins/certificates/certificates.go:112 +0x1b0
github.com/IBM/cbomkit-theia/provider/filesystem.(*PlainFilesystem).WalkDir.PlainFilesystem.WalkDir.func1({0x1400cd2cbd0, 0x82}, {0x105acdd00?, 0x1400cd297c0?}, {0x0?, 0x0?})
	/Users/dubera9/cbomkit/cbomkit-theia/provider/filesystem/filesystem.go:75 +0x80
path/filepath.walkDir({0x1400cd2cbd0, 0x82}, {0x105acdd00, 0x1400cd297c0}, 0x14000614e98)
	/opt/homebrew/Cellar/go/1.25.4/libexec/src/path/filepath/path.go:310 +0x44
path/filepath.walkDir({0x1400cd38000, 0x79}, {0x105acdd00, 0x1400cd29340}, 0x14000614e98)