### PR TITLE
encrypted private key handling

### DIFF
--- a/scanner/pem/pem.go
+++ b/scanner/pem/pem.go
@@ -18,12 +18,17 @@ package pem
 
 import (
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/cbomkit/cbomkit-theia/scanner/key"
 
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -57,6 +62,55 @@ const (
 	BlockTypeOPENSSHPrivateKey   BlockType = "OPENSSH PRIVATE KEY"
 )
 
+// pbkdf2Params mirrors RFC 8018's PBKDF2-params. PRF defaults to HMAC-SHA1 per the RFC
+// when omitted, which is why it is optional here rather than required.
+type pbkdf2Params struct {
+	Salt           asn1.RawValue
+	IterationCount int
+	KeyLength      int                      `asn1:"optional"`
+	PRF            pkix.AlgorithmIdentifier `asn1:"optional"`
+}
+
+// encryptionAlgorithmOIDNames maps OIDs used in PKCS8/PKCS12 password-based encryption
+// (PBES2, its KDFs and PBKDF2 PRFs, its cipher schemes, and legacy direct PBE schemes) to
+// human-readable names. OIDs are globally unique, so sharing one table across these
+// categories cannot cause a collision.
+var encryptionAlgorithmOIDNames = map[string]string{
+	// PBES2 (RFC 8018) and its KDFs
+	"1.2.840.113549.1.5.13":  "PBES2",
+	"1.2.840.113549.1.5.12":  "PBKDF2",
+	"1.3.6.1.4.1.11591.4.11": "scrypt",
+
+	// PBKDF2 pseudo-random functions (RFC 8018)
+	"1.2.840.113549.2.7":  "HMAC-SHA1",
+	"1.2.840.113549.2.8":  "HMAC-SHA224",
+	"1.2.840.113549.2.9":  "HMAC-SHA256",
+	"1.2.840.113549.2.10": "HMAC-SHA384",
+	"1.2.840.113549.2.11": "HMAC-SHA512",
+	"1.2.840.113549.2.12": "HMAC-SHA512-224",
+	"1.2.840.113549.2.13": "HMAC-SHA512-256",
+
+	// PBES2 cipher schemes
+	"2.16.840.1.101.3.4.1.2":  "AES-128-CBC",
+	"2.16.840.1.101.3.4.1.22": "AES-192-CBC",
+	"2.16.840.1.101.3.4.1.42": "AES-256-CBC",
+	"2.16.840.1.101.3.4.1.6":  "AES-128-GCM",
+	"2.16.840.1.101.3.4.1.26": "AES-192-GCM",
+	"2.16.840.1.101.3.4.1.46": "AES-256-GCM",
+	"1.2.840.113549.3.7":      "DES-EDE3-CBC",
+	"1.3.14.3.2.7":            "DES-CBC",
+
+	// Legacy direct (non-PBES2) PKCS5/PKCS12 password-based encryption schemes
+	"1.2.840.113549.1.5.3":    "pbeWithMD5AndDES-CBC",
+	"1.2.840.113549.1.5.10":   "pbeWithSHA1AndDES-CBC",
+	"1.2.840.113549.1.12.1.1": "pbeWithSHAAnd128BitRC4",
+	"1.2.840.113549.1.12.1.2": "pbeWithSHAAnd40BitRC4",
+	"1.2.840.113549.1.12.1.3": "pbeWithSHAAnd3-KeyTripleDES-CBC",
+	"1.2.840.113549.1.12.1.4": "pbeWithSHAAnd2-KeyTripleDES-CBC",
+	"1.2.840.113549.1.12.1.5": "pbeWithSHAAnd128BitRC2-CBC",
+	"1.2.840.113549.1.12.1.6": "pbeWithSHAAnd40BitRC2-CBC",
+}
+
 // ParsePEMToBlocksWithTypeFilter Just like ParsePEMToBlocksWithTypes but uses a filter for filtering
 func ParsePEMToBlocksWithTypeFilter(raw []byte, filter Filter) map[*pem.Block]BlockType {
 	blocksWithType := parsePEMToBlocksWithTypes(raw)
@@ -79,15 +133,23 @@ func GenerateCdxComponents(block *pem.Block) ([]cdx.Component, error) {
 			return []cdx.Component{}, err
 		}
 		return key.GenerateCdxComponents([]any{rawKey})
+	case BlockTypeEncryptedPrivateKey:
+		return pkcs8EncryptionComponents(block.Bytes), nil
 	case BlockTypeECPrivateKey:
 		rawKey, err := x509.ParseECPrivateKey(block.Bytes)
 		if err != nil {
+			if components, encrypted := legacyEncryptionComponents(block.Headers); encrypted {
+				return components, nil
+			}
 			return []cdx.Component{}, err
 		}
 		return key.GenerateCdxComponents([]any{rawKey, &rawKey.PublicKey})
 	case BlockTypeRSAPrivateKey:
 		rawKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 		if err != nil {
+			if components, encrypted := legacyEncryptionComponents(block.Headers); encrypted {
+				return components, nil
+			}
 			return []cdx.Component{}, err
 		}
 		return key.GenerateCdxComponents([]any{rawKey, &rawKey.PublicKey})
@@ -111,6 +173,155 @@ func GenerateCdxComponents(block *pem.Block) ([]cdx.Component, error) {
 		return key.GenerateCdxComponents([]any{rawKey})
 	default:
 		return []cdx.Component{}, fmt.Errorf("could not generate component from PEM. Block type is unknown or not a key")
+	}
+}
+
+// oidName looks up a human-readable name for an OID, falling back to its dotted form.
+func oidName(oid asn1.ObjectIdentifier) string {
+	if name, ok := encryptionAlgorithmOIDNames[oid.String()]; ok {
+		return name
+	}
+	return oid.String()
+}
+
+// legacyEncryptionComponents reports whether a PEM block carries the legacy OpenSSL
+// "Proc-Type: 4,ENCRYPTED" / "DEK-Info: <cipher>,<iv>" headers, and if so, builds the
+// encrypted-key component together with a standalone algorithm component for its cipher.
+func legacyEncryptionComponents(headers map[string]string) (components []cdx.Component, encrypted bool) {
+	procType, ok := headers["Proc-Type"]
+	if !ok || !strings.Contains(procType, "ENCRYPTED") {
+		return nil, false
+	}
+	cipherName := "PEM legacy encryption,Cipher Unknown"
+	if dekInfo, ok := headers["DEK-Info"]; ok {
+		if cipher, _, _ := strings.Cut(dekInfo, ","); cipher != "" {
+			cipherName = cipher
+		}
+	}
+	return encryptedPrivateKeyComponents(cipherName), true
+}
+
+// pkcs8EncryptionComponents inspects the outer EncryptedPrivateKeyInfo ASN.1 structure of a
+// standard PKCS8 "ENCRYPTED PRIVATE KEY" block to identify the encryption scheme in use, and
+// builds the encrypted-key component together with algorithm components describing it.
+func pkcs8EncryptionComponents(der []byte) []cdx.Component {
+	var info struct {
+		Algorithm pkix.AlgorithmIdentifier
+		Encrypted asn1.RawValue
+	}
+	if _, err := asn1.Unmarshal(der, &info); err != nil {
+		log.WithError(err).Debug("Could not parse EncryptedPrivateKeyInfo; recording as generic encrypted private key")
+		return encryptedPrivateKeyComponents("PKCS#8 encrypted private key")
+	}
+
+	oid := info.Algorithm.Algorithm.String()
+	name, ok := encryptionAlgorithmOIDNames[oid]
+	if !ok {
+		return encryptedPrivateKeyComponents(fmt.Sprintf("PKCS#8 encrypted private key (%s)", oid))
+	}
+	if name != "PBES2" {
+		// legacyPBEEncryptionComponents builds components for the pre-PBES2 password-based encryption
+		// schemes: RFC 8018 §6.1 PBES1 ("pbeWithMD5AndDES-CBC", "pbeWithSHA1AndDES-CBC") and the PKCS#12
+		// Appendix B schemes ("pbeWithSHAAnd..."). Both fuse the cipher and KDF into a single OID, so
+		// unlike PBES2 they can't be split into separate cipher/KDF algorithm components.
+		return encryptedPrivateKeyComponents(name)
+	}
+	return pbes2EncryptionComponents(name, info.Algorithm.Parameters.FullBytes)
+}
+
+// pbes2EncryptionComponents builds components for PBES2 (RFC 8018 §6.2), which names its cipher
+// (encryptionScheme) and KDF (keyDerivationFunc) as separate AlgorithmIdentifiers, unwrapped here
+// into their own algorithm components.
+func pbes2EncryptionComponents(name string, params []byte) []cdx.Component {
+	var scheme struct {
+		KDF    pkix.AlgorithmIdentifier
+		Cipher pkix.AlgorithmIdentifier
+	}
+	if _, err := asn1.Unmarshal(params, &scheme); err != nil {
+		log.WithError(err).Debug("Could not parse PBES2-params; recording as generic PBES2 encryption")
+		return encryptedPrivateKeyComponents(name)
+	}
+	cipherComponent := makeAlgorithmComponent(oidName(scheme.Cipher.Algorithm), cdx.CryptoPrimitiveBlockCipher)
+	keyComponent := newEncryptedPrivateKeyComponent(cdx.BOMReference(cipherComponent.BOMRef))
+	kdfComponent := pbes2KDFComponent(scheme.KDF)
+	return []cdx.Component{keyComponent, cipherComponent, kdfComponent}
+}
+
+// pbes2KDFComponent builds the algorithm component for a PBES2 keyDerivationFunc. When the KDF
+// is PBKDF2 (RFC 8018 §5.2), its PBKDF2-params are unwrapped to recover the PRF hash and fold it
+// into the component name; any other KDF (e.g. scrypt) is named as-is.
+func pbes2KDFComponent(kdfAlg pkix.AlgorithmIdentifier) cdx.Component {
+	kdfName := oidName(kdfAlg.Algorithm)
+	if kdfName != "PBKDF2" {
+		return makeAlgorithmComponent(kdfName, cdx.CryptoPrimitiveKDF)
+	}
+
+	var kdf pbkdf2Params
+	if _, err := asn1.Unmarshal(kdfAlg.Parameters.FullBytes, &kdf); err != nil {
+		log.WithError(err).Debug("Could not parse PBKDF2-params; omitting PRF from KDF component name")
+		return makeAlgorithmComponent(kdfName, cdx.CryptoPrimitiveKDF)
+	}
+	prfName := "HMAC-SHA1" // RFC 8018 default when the prf field is omitted
+	if len(kdf.PRF.Algorithm) > 0 {
+		prfName = oidName(kdf.PRF.Algorithm)
+	}
+	return makeAlgorithmComponent(fmt.Sprintf("%s-%s", kdfName, prfName), cdx.CryptoPrimitiveKDF)
+}
+
+// encryptedPrivateKeyComponents builds the encrypted-key component together with a single
+// algorithm component for a named cipher, for the cases where the cipher can't be separated
+// from its KDF (legacy PEM headers, legacy direct PKCS5/PKCS12 schemes) or the scheme couldn't
+// be parsed at all.
+func encryptedPrivateKeyComponents(cipherName string) []cdx.Component {
+	cipherComponent := makeAlgorithmComponent(cipherName, cdx.CryptoPrimitiveBlockCipher)
+	keyComponent := newEncryptedPrivateKeyComponent(cdx.BOMReference(cipherComponent.BOMRef))
+	return []cdx.Component{keyComponent, cipherComponent}
+}
+
+// makeAlgorithmComponent builds a standalone cryptographic-asset "algorithm" component for a
+// resolved algorithm name,its own generated BOMRef so other components can reference it via an *Ref field.
+func makeAlgorithmComponent(name string, primitive cdx.CryptoPrimitive) cdx.Component {
+	comp := cdx.Component{
+		Name:   name,
+		Type:   cdx.ComponentTypeCryptographicAsset,
+		BOMRef: uuid.New().String(),
+		CryptoProperties: &cdx.CryptoProperties{
+			AssetType:           cdx.CryptoAssetTypeAlgorithm,
+			AlgorithmProperties: &cdx.CryptoAlgorithmProperties{Primitive: primitive},
+		},
+	}
+	if primitive == cdx.CryptoPrimitiveBlockCipher {
+		upper := strings.ToUpper(name)
+		switch {
+		case strings.Contains(upper, "GCM"):
+			comp.CryptoProperties.AlgorithmProperties.Mode = cdx.CryptoAlgorithmModeGCM
+		case strings.Contains(upper, "CBC"):
+			comp.CryptoProperties.AlgorithmProperties.Mode = cdx.CryptoAlgorithmModeCBC
+		}
+	}
+	return comp
+}
+
+// newEncryptedPrivateKeyComponent builds a related-crypto-material component for a private key
+// whose contents are encrypted and therefore cannot be parsed into key material. Mechanism
+// records the protection category per the CycloneDX spec's examples ("HSM", "TPM", "SGX",
+// "Software", "None") — this package only ever detects software/password-based encryption — and
+// AlgorithmRef points at the cipher component that actually encrypts the key bytes.
+func newEncryptedPrivateKeyComponent(cipherRef cdx.BOMReference) cdx.Component {
+	return cdx.Component{
+		Name: "encrypted-private-key",
+		Type: cdx.ComponentTypeCryptographicAsset,
+		CryptoProperties: &cdx.CryptoProperties{
+			AssetType: cdx.CryptoAssetTypeRelatedCryptoMaterial,
+			RelatedCryptoMaterialProperties: &cdx.RelatedCryptoMaterialProperties{
+				Type:   cdx.RelatedCryptoMaterialTypePrivateKey,
+				Format: "PEM",
+				SecuredBy: &cdx.SecuredBy{
+					Mechanism:    "Software",
+					AlgorithmRef: cipherRef,
+				},
+			},
+		},
 	}
 }
 

--- a/scanner/pem/pem.go
+++ b/scanner/pem/pem.go
@@ -17,6 +17,8 @@
 package pem
 
 import (
+	"bytes"
+	"crypto/ed25519"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -71,10 +73,10 @@ type pbkdf2Params struct {
 	PRF            pkix.AlgorithmIdentifier `asn1:"optional"`
 }
 
-// encryptionAlgorithmOIDNames maps OIDs used in PKCS8/PKCS12 password-based encryption
-// (PBES2, its KDFs and PBKDF2 PRFs, its cipher schemes, and legacy direct PBE schemes) to
-// human-readable names. OIDs are globally unique, so sharing one table across these
-// categories cannot cause a collision.
+// encryptionAlgorithmOIDNames maps OIDs used in PKCS8 PBES2 password-based encryption (PBES2
+// itself, its KDFs and PBKDF2 PRFs) to human-readable names. OIDs are globally unique, so sharing
+// one table across these categories cannot cause a collision. PBES2 cipher schemes are looked up
+// via pbes2CipherSchemes instead, since those also need an explicit mode rather than an inferred one.
 var encryptionAlgorithmOIDNames = map[string]string{
 	// PBES2 (RFC 8018) and its KDFs
 	"1.2.840.113549.1.5.13":  "PBES2",
@@ -89,26 +91,206 @@ var encryptionAlgorithmOIDNames = map[string]string{
 	"1.2.840.113549.2.11": "HMAC-SHA512",
 	"1.2.840.113549.2.12": "HMAC-SHA512-224",
 	"1.2.840.113549.2.13": "HMAC-SHA512-256",
+}
 
-	// PBES2 cipher schemes
-	"2.16.840.1.101.3.4.1.2":  "AES-128-CBC",
-	"2.16.840.1.101.3.4.1.22": "AES-192-CBC",
-	"2.16.840.1.101.3.4.1.42": "AES-256-CBC",
-	"2.16.840.1.101.3.4.1.6":  "AES-128-GCM",
-	"2.16.840.1.101.3.4.1.26": "AES-192-GCM",
-	"2.16.840.1.101.3.4.1.46": "AES-256-GCM",
-	"1.2.840.113549.3.7":      "DES-EDE3-CBC",
-	"1.3.14.3.2.7":            "DES-CBC",
+// pbes2CipherScheme names a PBES2 (RFC 8018 §6.2) encryptionScheme OID and its cipher mode. The
+// mode is carried here rather than inferred from the name, since it's already known precisely
+// from which OID matched.
+type pbes2CipherScheme struct {
+	name string
+	mode cdx.CryptoAlgorithmMode
+}
 
-	// Legacy direct (non-PBES2) PKCS5/PKCS12 password-based encryption schemes
-	"1.2.840.113549.1.5.3":    "pbeWithMD5AndDES-CBC",
-	"1.2.840.113549.1.5.10":   "pbeWithSHA1AndDES-CBC",
-	"1.2.840.113549.1.12.1.1": "pbeWithSHAAnd128BitRC4",
-	"1.2.840.113549.1.12.1.2": "pbeWithSHAAnd40BitRC4",
-	"1.2.840.113549.1.12.1.3": "pbeWithSHAAnd3-KeyTripleDES-CBC",
-	"1.2.840.113549.1.12.1.4": "pbeWithSHAAnd2-KeyTripleDES-CBC",
-	"1.2.840.113549.1.12.1.5": "pbeWithSHAAnd128BitRC2-CBC",
-	"1.2.840.113549.1.12.1.6": "pbeWithSHAAnd40BitRC2-CBC",
+var pbes2CipherSchemes = map[string]pbes2CipherScheme{
+	"2.16.840.1.101.3.4.1.2":  {name: "AES-128-CBC", mode: cdx.CryptoAlgorithmModeCBC},
+	"2.16.840.1.101.3.4.1.22": {name: "AES-192-CBC", mode: cdx.CryptoAlgorithmModeCBC},
+	"2.16.840.1.101.3.4.1.42": {name: "AES-256-CBC", mode: cdx.CryptoAlgorithmModeCBC},
+	"2.16.840.1.101.3.4.1.6":  {name: "AES-128-GCM", mode: cdx.CryptoAlgorithmModeGCM},
+	"2.16.840.1.101.3.4.1.26": {name: "AES-192-GCM", mode: cdx.CryptoAlgorithmModeGCM},
+	"2.16.840.1.101.3.4.1.46": {name: "AES-256-GCM", mode: cdx.CryptoAlgorithmModeGCM},
+	"2.16.840.1.101.3.4.1.3":  {name: "AES-128-OFB", mode: cdx.CryptoAlgorithmModeOFB},
+	"2.16.840.1.101.3.4.1.23": {name: "AES-192-OFB", mode: cdx.CryptoAlgorithmModeOFB},
+	"2.16.840.1.101.3.4.1.43": {name: "AES-256-OFB", mode: cdx.CryptoAlgorithmModeOFB},
+	"2.16.840.1.101.3.4.1.4":  {name: "AES-128-CFB", mode: cdx.CryptoAlgorithmModeCFB},
+	"2.16.840.1.101.3.4.1.24": {name: "AES-192-CFB", mode: cdx.CryptoAlgorithmModeCFB},
+	"2.16.840.1.101.3.4.1.44": {name: "AES-256-CFB", mode: cdx.CryptoAlgorithmModeCFB},
+	"1.2.840.113549.3.7":      {name: "DES-EDE3-CBC", mode: cdx.CryptoAlgorithmModeCBC},
+	"1.3.14.3.2.7":            {name: "DES-CBC", mode: cdx.CryptoAlgorithmModeCBC},
+}
+
+// legacyPBEScheme describes a legacy (non-PBES2) password-based encryption OID: either RFC 8018
+// §6.1 PBES1 ("pbeWithMD5AndDES-CBC", "pbeWithSHA1AndDES-CBC") or a PKCS#12 Appendix B scheme
+// ("pbeWithSHAAnd..."). Both fuse their KDF and cipher into a single OID rather than naming them
+// as separate AlgorithmIdentifiers the way PBES2 does, so the split has to be hardcoded here.
+// cipherMode is empty for stream ciphers, which have no block mode.
+type legacyPBEScheme struct {
+	kdfName         string
+	cipherName      string
+	cipherPrimitive cdx.CryptoPrimitive
+	cipherMode      cdx.CryptoAlgorithmMode
+}
+
+var legacyPBESchemes = map[string]legacyPBEScheme{
+	// RFC 8018 §6.1 PBES1: PBKDF1 (parameterized by hash) with DES-CBC or RC2-CBC. PBES1 fixes
+	// RC2's effective key length rather than naming it, unlike the PKCS#12 RC2 variants below.
+	"1.2.840.113549.1.5.1":  {kdfName: "PBKDF1-MD2", cipherName: "DES-CBC", cipherPrimitive: cdx.CryptoPrimitiveBlockCipher, cipherMode: cdx.CryptoAlgorithmModeCBC},
+	"1.2.840.113549.1.5.3":  {kdfName: "PBKDF1-MD5", cipherName: "DES-CBC", cipherPrimitive: cdx.CryptoPrimitiveBlockCipher, cipherMode: cdx.CryptoAlgorithmModeCBC},
+	"1.2.840.113549.1.5.10": {kdfName: "PBKDF1-SHA1", cipherName: "DES-CBC", cipherPrimitive: cdx.CryptoPrimitiveBlockCipher, cipherMode: cdx.CryptoAlgorithmModeCBC},
+	"1.2.840.113549.1.5.4":  {kdfName: "PBKDF1-MD2", cipherName: "RC2-CBC", cipherPrimitive: cdx.CryptoPrimitiveBlockCipher, cipherMode: cdx.CryptoAlgorithmModeCBC},
+	"1.2.840.113549.1.5.6":  {kdfName: "PBKDF1-MD5", cipherName: "RC2-CBC", cipherPrimitive: cdx.CryptoPrimitiveBlockCipher, cipherMode: cdx.CryptoAlgorithmModeCBC},
+	"1.2.840.113549.1.5.11": {kdfName: "PBKDF1-SHA1", cipherName: "RC2-CBC", cipherPrimitive: cdx.CryptoPrimitiveBlockCipher, cipherMode: cdx.CryptoAlgorithmModeCBC},
+
+	// PKCS#12 Appendix B: the PKCS#12 KDF (always SHA1-based) with the named cipher. RC4 is a
+	// stream cipher; the DES/RC2 variants are all block ciphers run in CBC mode.
+	"1.2.840.113549.1.12.1.1": {kdfName: "PKCS#12 KDF-SHA1", cipherName: "RC4-128", cipherPrimitive: cdx.CryptoPrimitiveStreamCipher},
+	"1.2.840.113549.1.12.1.2": {kdfName: "PKCS#12 KDF-SHA1", cipherName: "RC4-40", cipherPrimitive: cdx.CryptoPrimitiveStreamCipher},
+	"1.2.840.113549.1.12.1.3": {kdfName: "PKCS#12 KDF-SHA1", cipherName: "DES-EDE3-CBC", cipherPrimitive: cdx.CryptoPrimitiveBlockCipher, cipherMode: cdx.CryptoAlgorithmModeCBC},
+	"1.2.840.113549.1.12.1.4": {kdfName: "PKCS#12 KDF-SHA1", cipherName: "DES-EDE2-CBC", cipherPrimitive: cdx.CryptoPrimitiveBlockCipher, cipherMode: cdx.CryptoAlgorithmModeCBC},
+	"1.2.840.113549.1.12.1.5": {kdfName: "PKCS#12 KDF-SHA1", cipherName: "RC2-128-CBC", cipherPrimitive: cdx.CryptoPrimitiveBlockCipher, cipherMode: cdx.CryptoAlgorithmModeCBC},
+	"1.2.840.113549.1.12.1.6": {kdfName: "PKCS#12 KDF-SHA1", cipherName: "RC2-40-CBC", cipherPrimitive: cdx.CryptoPrimitiveBlockCipher, cipherMode: cdx.CryptoAlgorithmModeCBC},
+}
+
+// opensshCipherScheme names an OpenSSH "openssh-key-v1" ciphername (see cipher.c in
+// openssh-portable) and its primitive/mode. Unlike PBES1/PBES2, OpenSSH's own key format already
+// carries the cipher and KDF (bcrypt) as separate named fields, so no fused-scheme split is needed.
+// parameterSetIdentifier and cryptoFunctions are only populated for AEAD ciphers, which have no
+// block-cipher mode to record but do have other CycloneDX-modeled parameters worth capturing.
+type opensshCipherScheme struct {
+	name                   string
+	primitive              cdx.CryptoPrimitive
+	mode                   cdx.CryptoAlgorithmMode
+	parameterSetIdentifier string
+	cryptoFunctions        []cdx.CryptoFunction
+}
+
+var opensshCipherSchemes = map[string]opensshCipherScheme{
+	// blowfish-cbc, cast128-cbc, rijndael-cbc@lysator.liu.se and the arcfour variants were removed
+	// from OpenSSH's own cipher list well before this change, but keys generated by older OpenSSH
+	// releases, or by other tools sharing this on-disk format, may still carry them. Key sizes below
+	// are taken from OpenSSH's cipher.c ciphers[] table (key_len field, in bytes): blowfish-cbc=16,
+	// cast128-cbc=16, rijndael-cbc@lysator.liu.se=32 (an alias for aes256-cbc, sharing its EVP cipher),
+	// arcfour=16, arcfour128=16 (plus a 1536-byte keystream discard), arcfour256=32 (same discard).
+	"blowfish-cbc":                {name: "Blowfish-128-CBC", primitive: cdx.CryptoPrimitiveBlockCipher, mode: cdx.CryptoAlgorithmModeCBC},
+	"cast128-cbc":                 {name: "CAST-128-CBC", primitive: cdx.CryptoPrimitiveBlockCipher, mode: cdx.CryptoAlgorithmModeCBC},
+	"rijndael-cbc@lysator.liu.se": {name: "AES-256-CBC", primitive: cdx.CryptoPrimitiveBlockCipher, mode: cdx.CryptoAlgorithmModeCBC},
+	"arcfour":                     {name: "RC4-128", primitive: cdx.CryptoPrimitiveStreamCipher},
+	"arcfour128":                  {name: "RC4-128", primitive: cdx.CryptoPrimitiveStreamCipher, parameterSetIdentifier: "1536-byte keystream discard"},
+	"arcfour256":                  {name: "RC4-256", primitive: cdx.CryptoPrimitiveStreamCipher, parameterSetIdentifier: "1536-byte keystream discard"},
+	"3des-cbc":                    {name: "DES-EDE3-CBC", primitive: cdx.CryptoPrimitiveBlockCipher, mode: cdx.CryptoAlgorithmModeCBC},
+	"aes128-cbc":                  {name: "AES-128-CBC", primitive: cdx.CryptoPrimitiveBlockCipher, mode: cdx.CryptoAlgorithmModeCBC},
+	"aes192-cbc":                  {name: "AES-192-CBC", primitive: cdx.CryptoPrimitiveBlockCipher, mode: cdx.CryptoAlgorithmModeCBC},
+	"aes256-cbc":                  {name: "AES-256-CBC", primitive: cdx.CryptoPrimitiveBlockCipher, mode: cdx.CryptoAlgorithmModeCBC},
+	"aes128-ctr":                  {name: "AES-128-CTR", primitive: cdx.CryptoPrimitiveBlockCipher, mode: cdx.CryptoAlgorithmModeCTR},
+	"aes192-ctr":                  {name: "AES-192-CTR", primitive: cdx.CryptoPrimitiveBlockCipher, mode: cdx.CryptoAlgorithmModeCTR},
+	"aes256-ctr":                  {name: "AES-256-CTR", primitive: cdx.CryptoPrimitiveBlockCipher, mode: cdx.CryptoAlgorithmModeCTR},
+	// OpenSSH's cipher.c gives both GCM ciphers a 12-byte (96-bit) IV and 16-byte (128-bit) auth
+	// tag. The 96-bit nonce's construction (a 4-byte fixed field plus an 8-byte per-packet
+	// invocation counter, rather than a random nonce) is specified by RFC 5647 (AES-GCM for SSH),
+	// not the C source itself.
+	"aes128-gcm@openssh.com": {
+		name:                   "AES-128-GCM",
+		primitive:              cdx.CryptoPrimitiveBlockCipher,
+		mode:                   cdx.CryptoAlgorithmModeGCM,
+		parameterSetIdentifier: "96-bit nonce (RFC 5647: 4-byte fixed field + 8-byte invocation counter), 128-bit tag",
+		cryptoFunctions:        []cdx.CryptoFunction{cdx.CryptoFunctionEncrypt, cdx.CryptoFunctionDecrypt, cdx.CryptoFunctionTag},
+	},
+	"aes256-gcm@openssh.com": {
+		name:                   "AES-256-GCM",
+		primitive:              cdx.CryptoPrimitiveBlockCipher,
+		mode:                   cdx.CryptoAlgorithmModeGCM,
+		parameterSetIdentifier: "96-bit nonce (RFC 5647: 4-byte fixed field + 8-byte invocation counter), 128-bit tag",
+		cryptoFunctions:        []cdx.CryptoFunction{cdx.CryptoFunctionEncrypt, cdx.CryptoFunctionDecrypt, cdx.CryptoFunctionTag},
+	},
+	// OpenSSH's construction (cipher-chachapoly.c) splits a 512-bit key into two independent
+	// 256-bit ChaCha20 subkeys: one encrypts the packet payload and generates the Poly1305 key,
+	// the other separately encrypts the packet length field; the 64-bit packet sequence number is
+	// used as the nonce for both, rather than a random or counter-based nonce. The 128-bit tag
+	// covers the encrypted length field plus ciphertext.
+	"chacha20-poly1305@openssh.com": {
+		name:                   "ChaCha20-Poly1305",
+		primitive:              cdx.CryptoPrimitiveAE,
+		parameterSetIdentifier: "512-bit key (two 256-bit ChaCha20 subkeys: payload+MAC, length field), 64-bit sequence-number nonce, 128-bit tag",
+		cryptoFunctions:        []cdx.CryptoFunction{cdx.CryptoFunctionEncrypt, cdx.CryptoFunctionDecrypt, cdx.CryptoFunctionTag},
+	},
+}
+
+// opensshKeyMagic is the fixed header of the OpenSSH "openssh-key-v1" private key wire format. See
+// https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key.
+const opensshKeyMagic = "openssh-key-v1\x00"
+
+// opensshEncryptionComponents inspects the header of an OpenSSH "openssh-key-v1" private key
+// (block.Bytes of an "OPENSSH PRIVATE KEY" PEM block) to identify its cipher and KDF. Unlike
+// ssh.ParseRawPrivateKey, this only reads the plaintext header fields (ciphername, kdfname) that
+// precede the encrypted key material, so it works without the passphrase.
+func opensshEncryptionComponents(keyBytes []byte) []cdx.Component {
+	if !bytes.HasPrefix(keyBytes, []byte(opensshKeyMagic)) {
+		return encryptedPrivateKeyComponents("OpenSSH encrypted private key", cdx.CryptoPrimitiveUnknown, "")
+	}
+
+	var header struct {
+		CipherName   string
+		KdfName      string
+		KdfOpts      string
+		NumKeys      uint32
+		PubKey       []byte
+		PrivKeyBlock []byte
+		Rest         []byte `ssh:"rest"`
+	}
+	if err := ssh.Unmarshal(keyBytes[len(opensshKeyMagic):], &header); err != nil {
+		log.WithError(err).Debug("Could not parse OpenSSH private key header; recording as generic encrypted private key")
+		return encryptedPrivateKeyComponents("OpenSSH encrypted private key", cdx.CryptoPrimitiveUnknown, "")
+	}
+
+	var cipherComponent cdx.Component
+	if cipher, ok := opensshCipherSchemes[header.CipherName]; ok {
+		cipherComponent = makeAlgorithmComponent(cipher.name, cipher.primitive, cipher.mode)
+		if cipher.parameterSetIdentifier != "" {
+			cipherComponent.CryptoProperties.AlgorithmProperties.ParameterSetIdentifier = cipher.parameterSetIdentifier
+		}
+		if len(cipher.cryptoFunctions) > 0 {
+			cipherComponent.CryptoProperties.AlgorithmProperties.CryptoFunctions = &cipher.cryptoFunctions
+		}
+	} else {
+		cipherComponent = makeAlgorithmComponent(header.CipherName, cdx.CryptoPrimitiveUnknown, "")
+	}
+	keyComponent := newEncryptedPrivateKeyComponent(cdx.BOMReference(cipherComponent.BOMRef))
+	kdfComponent := makeAlgorithmComponent(header.KdfName, cdx.CryptoPrimitiveKDF, "")
+	components := []cdx.Component{keyComponent, cipherComponent, kdfComponent}
+
+	if pubKeyComponent, ok := opensshPublicKeyComponent(header.PubKey); ok {
+		components = append(components, pubKeyComponent)
+	}
+	return components
+}
+
+// opensshPublicKeyComponent parses the plaintext public key blob embedded in an OpenSSH
+// "openssh-key-v1" private key header (stored unencrypted specifically so implementations can
+// identify the key type without a passphrase, per PROTOCOL.key) and builds a CBOM component
+// describing the underlying asymmetric key algorithm. It returns ok=false if the blob can't be
+// parsed or its key type isn't one key.GenerateCdxComponent knows how to describe.
+func opensshPublicKeyComponent(pubKeyBytes []byte) (cdx.Component, bool) {
+	sshPubKey, err := ssh.ParsePublicKey(pubKeyBytes)
+	if err != nil {
+		log.WithError(err).Debug("Could not parse OpenSSH public key header; omitting key type metadata")
+		return cdx.Component{}, false
+	}
+
+	cryptoPubKey, ok := sshPubKey.(ssh.CryptoPublicKey)
+	if !ok {
+		return cdx.Component{}, false
+	}
+
+	rawPubKey := cryptoPubKey.CryptoPublicKey()
+	if edPubKey, ok := rawPubKey.(ed25519.PublicKey); ok {
+		rawPubKey = &edPubKey
+	}
+
+	component, err := key.GenerateCdxComponent(rawPubKey)
+	if err != nil {
+		log.WithError(err).Debug("Could not describe OpenSSH public key algorithm; omitting key type metadata")
+		return cdx.Component{}, false
+	}
+	return *component, true
 }
 
 // ParsePEMToBlocksWithTypeFilter Just like ParsePEMToBlocksWithTypes but uses a filter for filtering
@@ -130,6 +312,9 @@ func GenerateCdxComponents(block *pem.Block) ([]cdx.Component, error) {
 	case BlockTypePrivateKey:
 		rawKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 		if err != nil {
+			if looksLikeEncryptedPKCS8(block.Bytes) {
+				return pkcs8EncryptionComponents(block.Bytes), nil
+			}
 			return []cdx.Component{}, err
 		}
 		return key.GenerateCdxComponents([]any{rawKey})
@@ -168,6 +353,9 @@ func GenerateCdxComponents(block *pem.Block) ([]cdx.Component, error) {
 	case BlockTypeOPENSSHPrivateKey:
 		rawKey, err := ssh.ParseRawPrivateKey(pem.EncodeToMemory(block))
 		if err != nil {
+			if _, ok := err.(*ssh.PassphraseMissingError); ok {
+				return opensshEncryptionComponents(block.Bytes), nil
+			}
 			return []cdx.Component{}, err
 		}
 		return key.GenerateCdxComponents([]any{rawKey})
@@ -193,40 +381,97 @@ func legacyEncryptionComponents(headers map[string]string) (components []cdx.Com
 		return nil, false
 	}
 	cipherName := "PEM legacy encryption,Cipher Unknown"
+	primitive := cdx.CryptoPrimitiveUnknown
+	var mode cdx.CryptoAlgorithmMode
 	if dekInfo, ok := headers["DEK-Info"]; ok {
 		if cipher, _, _ := strings.Cut(dekInfo, ","); cipher != "" {
 			cipherName = cipher
+			primitive = cdx.CryptoPrimitiveBlockCipher
+			mode = cipherModeFromName(cipher)
 		}
 	}
-	return encryptedPrivateKeyComponents(cipherName), true
+	return encryptedPrivateKeyComponents(cipherName, primitive, mode), true
+}
+
+// cipherModeFromName infers a block-cipher mode from an OpenSSL DEK-Info cipher spec string (e.g.
+// "AES-256-CBC", "DES-EDE3-CBC"). Unlike the OID-keyed lookups elsewhere in this file, DEK-Info
+// values are arbitrary free text with no structured table to resolve them against, so this is the
+// one place a substring match on the name is unavoidable. Unrecognized suffixes leave the mode unset.
+func cipherModeFromName(name string) cdx.CryptoAlgorithmMode {
+	upper := strings.ToUpper(name)
+	switch {
+	case strings.Contains(upper, "GCM"):
+		return cdx.CryptoAlgorithmModeGCM
+	case strings.Contains(upper, "CBC"):
+		return cdx.CryptoAlgorithmModeCBC
+	case strings.Contains(upper, "OFB"):
+		return cdx.CryptoAlgorithmModeOFB
+	case strings.Contains(upper, "CFB"):
+		return cdx.CryptoAlgorithmModeCFB
+	case strings.Contains(upper, "CTR"):
+		return cdx.CryptoAlgorithmModeCTR
+	case strings.Contains(upper, "ECB"):
+		return cdx.CryptoAlgorithmModeECB
+	}
+	return ""
+}
+
+// pkcs8EncryptedPrivateKeyInfo mirrors PKCS8's EncryptedPrivateKeyInfo (RFC 5958 §3): SEQUENCE {
+// encryptionAlgorithm AlgorithmIdentifier, encryptedData OCTET STRING }. Its first field is a
+// SEQUENCE (AlgorithmIdentifier), unlike PrivateKeyInfo's first field, which is an INTEGER
+// (version) — so successfully decoding into this shape is a reasonable signal that DER content is
+// encrypted PKCS8, even when it arrived in a PEM block labeled "PRIVATE KEY" rather than
+// "ENCRYPTED PRIVATE KEY" (some tools mislabel it this way).
+type pkcs8EncryptedPrivateKeyInfo struct {
+	Algorithm pkix.AlgorithmIdentifier
+	Encrypted asn1.RawValue
+}
+
+// looksLikeEncryptedPKCS8 reports whether der decodes as pkcs8EncryptedPrivateKeyInfo, used to
+// distinguish a mislabeled encrypted PKCS8 key from genuinely malformed key material before
+// treating x509.ParsePKCS8PrivateKey's failure as encryption rather than corruption.
+func looksLikeEncryptedPKCS8(der []byte) bool {
+	var info pkcs8EncryptedPrivateKeyInfo
+	_, err := asn1.Unmarshal(der, &info)
+	return err == nil
 }
 
 // pkcs8EncryptionComponents inspects the outer EncryptedPrivateKeyInfo ASN.1 structure of a
-// standard PKCS8 "ENCRYPTED PRIVATE KEY" block to identify the encryption scheme in use, and
-// builds the encrypted-key component together with algorithm components describing it.
+// standard PKCS8 encrypted private key (whether from an "ENCRYPTED PRIVATE KEY" block, or a
+// mislabeled "PRIVATE KEY" block that looksLikeEncryptedPKCS8 confirmed is actually encrypted) to
+// identify the encryption scheme in use, and builds the encrypted-key component together with
+// algorithm components describing it.
 func pkcs8EncryptionComponents(der []byte) []cdx.Component {
-	var info struct {
-		Algorithm pkix.AlgorithmIdentifier
-		Encrypted asn1.RawValue
-	}
+	var info pkcs8EncryptedPrivateKeyInfo
 	if _, err := asn1.Unmarshal(der, &info); err != nil {
 		log.WithError(err).Debug("Could not parse EncryptedPrivateKeyInfo; recording as generic encrypted private key")
-		return encryptedPrivateKeyComponents("PKCS#8 encrypted private key")
+		return encryptedPrivateKeyComponents("PKCS#8 encrypted private key", cdx.CryptoPrimitiveUnknown, "")
 	}
 
 	oid := info.Algorithm.Algorithm.String()
+	if scheme, ok := legacyPBESchemes[oid]; ok {
+		return legacyPBEComponents(scheme)
+	}
+
 	name, ok := encryptionAlgorithmOIDNames[oid]
 	if !ok {
-		return encryptedPrivateKeyComponents(fmt.Sprintf("PKCS#8 encrypted private key (%s)", oid))
+		return encryptedPrivateKeyComponents(fmt.Sprintf("PKCS#8 encrypted private key (%s)", oid), cdx.CryptoPrimitiveUnknown, "")
 	}
 	if name != "PBES2" {
-		// legacyPBEEncryptionComponents builds components for the pre-PBES2 password-based encryption
-		// schemes: RFC 8018 §6.1 PBES1 ("pbeWithMD5AndDES-CBC", "pbeWithSHA1AndDES-CBC") and the PKCS#12
-		// Appendix B schemes ("pbeWithSHAAnd..."). Both fuse the cipher and KDF into a single OID, so
-		// unlike PBES2 they can't be split into separate cipher/KDF algorithm components.
-		return encryptedPrivateKeyComponents(name)
+		//Defensive code,will not reach here for well formed input, it will protect from malformed input where the outer OID happens to collide with one of those inner-only OIDs.
+		return encryptedPrivateKeyComponents(name, cdx.CryptoPrimitiveUnknown, "")
 	}
 	return pbes2EncryptionComponents(name, info.Algorithm.Parameters.FullBytes)
+}
+
+// legacyPBEComponents builds separate cipher and KDF algorithm components for a legacy
+// (non-PBES2) password-based encryption scheme, mirroring how pbes2EncryptionComponents splits
+// PBES2's own explicit cipher/KDF AlgorithmIdentifiers.
+func legacyPBEComponents(scheme legacyPBEScheme) []cdx.Component {
+	cipherComponent := makeAlgorithmComponent(scheme.cipherName, scheme.cipherPrimitive, scheme.cipherMode)
+	keyComponent := newEncryptedPrivateKeyComponent(cdx.BOMReference(cipherComponent.BOMRef))
+	kdfComponent := makeAlgorithmComponent(scheme.kdfName, cdx.CryptoPrimitiveKDF, "")
+	return []cdx.Component{keyComponent, cipherComponent, kdfComponent}
 }
 
 // pbes2EncryptionComponents builds components for PBES2 (RFC 8018 §6.2), which names its cipher
@@ -239,9 +484,15 @@ func pbes2EncryptionComponents(name string, params []byte) []cdx.Component {
 	}
 	if _, err := asn1.Unmarshal(params, &scheme); err != nil {
 		log.WithError(err).Debug("Could not parse PBES2-params; recording as generic PBES2 encryption")
-		return encryptedPrivateKeyComponents(name)
+		return encryptedPrivateKeyComponents(name, cdx.CryptoPrimitiveUnknown, "")
 	}
-	cipherComponent := makeAlgorithmComponent(oidName(scheme.Cipher.Algorithm), cdx.CryptoPrimitiveBlockCipher)
+
+	var cipherComponent cdx.Component
+	if cipher, ok := pbes2CipherSchemes[scheme.Cipher.Algorithm.String()]; ok {
+		cipherComponent = makeAlgorithmComponent(cipher.name, cdx.CryptoPrimitiveBlockCipher, cipher.mode)
+	} else {
+		cipherComponent = makeAlgorithmComponent(scheme.Cipher.Algorithm.String(), cdx.CryptoPrimitiveUnknown, "")
+	}
 	keyComponent := newEncryptedPrivateKeyComponent(cdx.BOMReference(cipherComponent.BOMRef))
 	kdfComponent := pbes2KDFComponent(scheme.KDF)
 	return []cdx.Component{keyComponent, cipherComponent, kdfComponent}
@@ -253,34 +504,34 @@ func pbes2EncryptionComponents(name string, params []byte) []cdx.Component {
 func pbes2KDFComponent(kdfAlg pkix.AlgorithmIdentifier) cdx.Component {
 	kdfName := oidName(kdfAlg.Algorithm)
 	if kdfName != "PBKDF2" {
-		return makeAlgorithmComponent(kdfName, cdx.CryptoPrimitiveKDF)
+		return makeAlgorithmComponent(kdfName, cdx.CryptoPrimitiveKDF, "")
 	}
 
 	var kdf pbkdf2Params
 	if _, err := asn1.Unmarshal(kdfAlg.Parameters.FullBytes, &kdf); err != nil {
 		log.WithError(err).Debug("Could not parse PBKDF2-params; omitting PRF from KDF component name")
-		return makeAlgorithmComponent(kdfName, cdx.CryptoPrimitiveKDF)
+		return makeAlgorithmComponent(kdfName, cdx.CryptoPrimitiveKDF, "")
 	}
 	prfName := "HMAC-SHA1" // RFC 8018 default when the prf field is omitted
 	if len(kdf.PRF.Algorithm) > 0 {
 		prfName = oidName(kdf.PRF.Algorithm)
 	}
-	return makeAlgorithmComponent(fmt.Sprintf("%s-%s", kdfName, prfName), cdx.CryptoPrimitiveKDF)
+	return makeAlgorithmComponent(fmt.Sprintf("%s-%s", kdfName, prfName), cdx.CryptoPrimitiveKDF, "")
 }
 
 // encryptedPrivateKeyComponents builds the encrypted-key component together with a single
-// algorithm component for a named cipher, for the cases where the cipher can't be separated
-// from its KDF (legacy PEM headers, legacy direct PKCS5/PKCS12 schemes) or the scheme couldn't
-// be parsed at all.
-func encryptedPrivateKeyComponents(cipherName string) []cdx.Component {
-	cipherComponent := makeAlgorithmComponent(cipherName, cdx.CryptoPrimitiveBlockCipher)
+// algorithm component for a resolved cipher name, or a placeholder name (tagged
+// CryptoPrimitiveUnknown) for the cases where the scheme couldn't be identified or parsed at all.
+func encryptedPrivateKeyComponents(cipherName string, primitive cdx.CryptoPrimitive, mode cdx.CryptoAlgorithmMode) []cdx.Component {
+	cipherComponent := makeAlgorithmComponent(cipherName, primitive, mode)
 	keyComponent := newEncryptedPrivateKeyComponent(cdx.BOMReference(cipherComponent.BOMRef))
 	return []cdx.Component{keyComponent, cipherComponent}
 }
 
 // makeAlgorithmComponent builds a standalone cryptographic-asset "algorithm" component for a
-// resolved algorithm name,its own generated BOMRef so other components can reference it via an *Ref field.
-func makeAlgorithmComponent(name string, primitive cdx.CryptoPrimitive) cdx.Component {
+// resolved algorithm name and mode (mode may be empty when not applicable), with its own
+// generated BOMRef so other components can reference it via an *Ref field.
+func makeAlgorithmComponent(name string, primitive cdx.CryptoPrimitive, mode cdx.CryptoAlgorithmMode) cdx.Component {
 	comp := cdx.Component{
 		Name:   name,
 		Type:   cdx.ComponentTypeCryptographicAsset,
@@ -290,14 +541,8 @@ func makeAlgorithmComponent(name string, primitive cdx.CryptoPrimitive) cdx.Comp
 			AlgorithmProperties: &cdx.CryptoAlgorithmProperties{Primitive: primitive},
 		},
 	}
-	if primitive == cdx.CryptoPrimitiveBlockCipher {
-		upper := strings.ToUpper(name)
-		switch {
-		case strings.Contains(upper, "GCM"):
-			comp.CryptoProperties.AlgorithmProperties.Mode = cdx.CryptoAlgorithmModeGCM
-		case strings.Contains(upper, "CBC"):
-			comp.CryptoProperties.AlgorithmProperties.Mode = cdx.CryptoAlgorithmModeCBC
-		}
+	if mode != "" {
+		comp.CryptoProperties.AlgorithmProperties.Mode = mode
 	}
 	return comp
 }
@@ -309,8 +554,9 @@ func makeAlgorithmComponent(name string, primitive cdx.CryptoPrimitive) cdx.Comp
 // AlgorithmRef points at the cipher component that actually encrypts the key bytes.
 func newEncryptedPrivateKeyComponent(cipherRef cdx.BOMReference) cdx.Component {
 	return cdx.Component{
-		Name: "encrypted-private-key",
-		Type: cdx.ComponentTypeCryptographicAsset,
+		Name:   "encrypted-private-key",
+		Type:   cdx.ComponentTypeCryptographicAsset,
+		BOMRef: uuid.New().String(),
 		CryptoProperties: &cdx.CryptoProperties{
 			AssetType: cdx.CryptoAssetTypeRelatedCryptoMaterial,
 			RelatedCryptoMaterialProperties: &cdx.RelatedCryptoMaterialProperties{

--- a/scanner/pem/pem_test.go
+++ b/scanner/pem/pem_test.go
@@ -17,6 +17,8 @@
 package pem
 
 import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"testing"
 
@@ -211,12 +213,162 @@ func TestGenerateCdxComponentsPKCS8LegacyDirectPBEScheme(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error for a recognized encrypted key, got: %v", err)
 	}
-	assert.Len(t, components, 2)
+	// The encrypted-key component, plus separate cipher and KDF components: PKCS#12 Appendix B
+	// schemes fuse a KDF and a cipher into one OID, but the identity of each is still known and
+	// should be reported as two distinct algorithm components, not one fused/mistyped one.
+	assert.Len(t, components, 3)
 	props := components[0].CryptoProperties.RelatedCryptoMaterialProperties
 	assert.NotNil(t, props.SecuredBy)
 	assert.Equal(t, "Software", props.SecuredBy.Mechanism)
 	assert.Equal(t, cdx.BOMReference(components[1].BOMRef), props.SecuredBy.AlgorithmRef)
-	assert.Equal(t, "pbeWithSHAAnd3-KeyTripleDES-CBC", components[1].Name)
+
+	cipher := components[1]
+	assert.Equal(t, "DES-EDE3-CBC", cipher.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveBlockCipher, cipher.CryptoProperties.AlgorithmProperties.Primitive)
+	assert.Equal(t, cdx.CryptoAlgorithmModeCBC, cipher.CryptoProperties.AlgorithmProperties.Mode)
+
+	kdf := components[2]
+	assert.Equal(t, "PKCS#12 KDF-SHA1", kdf.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveKDF, kdf.CryptoProperties.AlgorithmProperties.Primitive)
+}
+
+// pbeWithSHAAnd128BitRC4 fuses a stream cipher (RC4) into its OID, unlike every other legacy PBE
+// scheme, which fuses a block cipher. Its cipher component must be tagged CryptoPrimitiveStreamCipher,
+// not CryptoPrimitiveBlockCipher. The EncryptedPrivateKeyInfo DER is built directly via asn1.Marshal
+// (rather than a captured openssl fixture) since only the outer AlgorithmIdentifier OID matters here.
+func TestGenerateCdxComponentsPKCS8LegacyRC4Scheme(t *testing.T) {
+	type pbeParameter struct {
+		Salt           []byte
+		IterationCount int
+	}
+	type encryptedPrivateKeyInfo struct {
+		Algorithm pkix.AlgorithmIdentifier
+		Encrypted []byte
+	}
+
+	params, err := asn1.Marshal(pbeParameter{Salt: []byte{1, 2, 3, 4, 5, 6, 7, 8}, IterationCount: 2048})
+	if err != nil {
+		t.Fatalf("failed to marshal PBEParameter: %v", err)
+	}
+	der, err := asn1.Marshal(encryptedPrivateKeyInfo{
+		Algorithm: pkix.AlgorithmIdentifier{
+			Algorithm:  asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 12, 1, 1}, // pbeWithSHAAnd128BitRC4
+			Parameters: asn1.RawValue{FullBytes: params},
+		},
+		Encrypted: []byte{0xAA, 0xBB, 0xCC, 0xDD},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal EncryptedPrivateKeyInfo: %v", err)
+	}
+
+	components := pkcs8EncryptionComponents(der)
+	assert.Len(t, components, 3)
+
+	cipher := components[1]
+	assert.Equal(t, "RC4-128", cipher.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveStreamCipher, cipher.CryptoProperties.AlgorithmProperties.Primitive)
+	assert.Empty(t, cipher.CryptoProperties.AlgorithmProperties.Mode)
+
+	kdf := components[2]
+	assert.Equal(t, "PKCS#12 KDF-SHA1", kdf.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveKDF, kdf.CryptoProperties.AlgorithmProperties.Primitive)
+}
+
+// pbeWithSHA1AndRC2-CBC (RFC 8018 §6.1 PBES1) is one of the four PBES1/PKCS#12 gaps previously
+// missing from the OID table, falling back to a raw dotted-OID placeholder name. DER built via
+// asn1.Marshal since legacyPBEComponents never inspects Parameters, only the outer OID.
+func TestGenerateCdxComponentsPKCS8PBES1RC2Scheme(t *testing.T) {
+	type encryptedPrivateKeyInfo struct {
+		Algorithm pkix.AlgorithmIdentifier
+		Encrypted []byte
+	}
+
+	der, err := asn1.Marshal(encryptedPrivateKeyInfo{
+		Algorithm: pkix.AlgorithmIdentifier{
+			Algorithm: asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 11}, // pbeWithSHA1AndRC2-CBC
+		},
+		Encrypted: []byte{0xAA, 0xBB, 0xCC, 0xDD},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal EncryptedPrivateKeyInfo: %v", err)
+	}
+
+	components := pkcs8EncryptionComponents(der)
+	assert.Len(t, components, 3)
+
+	cipher := components[1]
+	assert.Equal(t, "RC2-CBC", cipher.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveBlockCipher, cipher.CryptoProperties.AlgorithmProperties.Primitive)
+	assert.Equal(t, cdx.CryptoAlgorithmModeCBC, cipher.CryptoProperties.AlgorithmProperties.Mode)
+
+	kdf := components[2]
+	assert.Equal(t, "PBKDF1-SHA1", kdf.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveKDF, kdf.CryptoProperties.AlgorithmProperties.Primitive)
+}
+
+// AES-128-OFB is one of the AES-CFB/OFB cipher-scheme OIDs previously missing from the PBES2
+// cipher table. DER built via asn1.Marshal to exercise the full PBES2 KDF/cipher unwrap path.
+func TestGenerateCdxComponentsPKCS8PBES2AESOFBCipher(t *testing.T) {
+	type pbes2Params struct {
+		KDF    pkix.AlgorithmIdentifier
+		Cipher pkix.AlgorithmIdentifier
+	}
+	type encryptedPrivateKeyInfo struct {
+		Algorithm pkix.AlgorithmIdentifier
+		Encrypted []byte
+	}
+
+	saltDER, err := asn1.Marshal([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	if err != nil {
+		t.Fatalf("failed to marshal salt: %v", err)
+	}
+	kdfParams, err := asn1.Marshal(pbkdf2Params{
+		Salt:           asn1.RawValue{FullBytes: saltDER},
+		IterationCount: 2048,
+		PRF:            pkix.AlgorithmIdentifier{Algorithm: asn1.ObjectIdentifier{1, 2, 840, 113549, 2, 9}}, // HMAC-SHA256
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal PBKDF2-params: %v", err)
+	}
+	ivDER, err := asn1.Marshal(make([]byte, 16))
+	if err != nil {
+		t.Fatalf("failed to marshal IV: %v", err)
+	}
+	schemeParams, err := asn1.Marshal(pbes2Params{
+		KDF: pkix.AlgorithmIdentifier{
+			Algorithm:  asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 12}, // PBKDF2
+			Parameters: asn1.RawValue{FullBytes: kdfParams},
+		},
+		Cipher: pkix.AlgorithmIdentifier{
+			Algorithm:  asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 1, 3}, // AES-128-OFB
+			Parameters: asn1.RawValue{FullBytes: ivDER},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal PBES2-params: %v", err)
+	}
+	der, err := asn1.Marshal(encryptedPrivateKeyInfo{
+		Algorithm: pkix.AlgorithmIdentifier{
+			Algorithm:  asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 5, 13}, // PBES2
+			Parameters: asn1.RawValue{FullBytes: schemeParams},
+		},
+		Encrypted: []byte{0xAA, 0xBB, 0xCC, 0xDD},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal EncryptedPrivateKeyInfo: %v", err)
+	}
+
+	components := pkcs8EncryptionComponents(der)
+	assert.Len(t, components, 3)
+
+	cipher := components[1]
+	assert.Equal(t, "AES-128-OFB", cipher.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveBlockCipher, cipher.CryptoProperties.AlgorithmProperties.Primitive)
+	assert.Equal(t, cdx.CryptoAlgorithmModeOFB, cipher.CryptoProperties.AlgorithmProperties.Mode)
+
+	kdf := components[2]
+	assert.Equal(t, "PBKDF2-HMAC-SHA256", kdf.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveKDF, kdf.CryptoProperties.AlgorithmProperties.Primitive)
 }
 
 func TestGenerateCdxComponentsUnencryptedMalformedKeyStillErrors(t *testing.T) {
@@ -225,6 +377,156 @@ func TestGenerateCdxComponentsUnencryptedMalformedKeyStillErrors(t *testing.T) {
 	raw := []byte("-----BEGIN RSA PRIVATE KEY-----\n" +
 		"MAA=\n" +
 		"-----END RSA PRIVATE KEY-----")
+
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("failed to decode test PEM block")
+	}
+
+	_, err := GenerateCdxComponents(block)
+	assert.Error(t, err)
+}
+
+func TestGenerateCdxComponentsOpenSSHPassphraseProtectedKey(t *testing.T) {
+	// Generated with: ssh-keygen -t ed25519 -N testpassphrase -C "" -f id_ed25519
+	raw := []byte("-----BEGIN OPENSSH PRIVATE KEY-----\n" +
+		"b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABBP9T2L6v\n" +
+		"A4w3OyEHctq1TkAAAAGAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIJv1oucckQBNTvBJ\n" +
+		"0wWhQDQzAMnGrii5VNlW1OgxCy2jAAAAkFy5+5SOjbvYfbO99XJYoLwN6jJ26J6GQjjJ56\n" +
+		"hwb3tLrcYTEQvLSC1n/rTF9mAp7k+X6Vw9I8M+CT40LzidTiPklIb93LugCub4hsNF88GH\n" +
+		"DQeuQfIfFs2J3vdwb5OQ8805LQi2L1NEB/buHGBzuigSeKg7qzyfWcagXqVPWWgbkogDAY\n" +
+		"VgHG4i9Ak2G+wwLg==\n" +
+		"-----END OPENSSH PRIVATE KEY-----")
+
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("failed to decode test PEM block")
+	}
+
+	components, err := GenerateCdxComponents(block)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assert.Len(t, components, 4)
+
+	cipher := components[1]
+	assert.Equal(t, "AES-256-CTR", cipher.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveBlockCipher, cipher.CryptoProperties.AlgorithmProperties.Primitive)
+	assert.Equal(t, cdx.CryptoAlgorithmModeCTR, cipher.CryptoProperties.AlgorithmProperties.Mode)
+
+	kdf := components[2]
+	assert.Equal(t, "bcrypt", kdf.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveKDF, kdf.CryptoProperties.AlgorithmProperties.Primitive)
+
+	key := components[0]
+	assert.Equal(t, cdx.CryptoAssetTypeRelatedCryptoMaterial, key.CryptoProperties.AssetType)
+	assert.Equal(t, cdx.RelatedCryptoMaterialTypePrivateKey, key.CryptoProperties.RelatedCryptoMaterialProperties.Type)
+	assert.Equal(t, cdx.BOMReference(cipher.BOMRef), key.CryptoProperties.RelatedCryptoMaterialProperties.SecuredBy.AlgorithmRef)
+
+	pubKey := components[3]
+	assert.Equal(t, "ED25519", pubKey.Name)
+	assert.Equal(t, cdx.CryptoAssetTypeRelatedCryptoMaterial, pubKey.CryptoProperties.AssetType)
+	assert.Equal(t, cdx.RelatedCryptoMaterialTypePublicKey, pubKey.CryptoProperties.RelatedCryptoMaterialProperties.Type)
+}
+
+// chacha20-poly1305@openssh.com is an AEAD construction with no applicable CryptoAlgorithmMode, so
+// its extra detail is carried in ParameterSetIdentifier/CryptoFunctions instead.
+func TestGenerateCdxComponentsOpenSSHChaCha20Poly1305(t *testing.T) {
+	// Generated with: ssh-keygen -t ed25519 -N testpassphrase -Z chacha20-poly1305@openssh.com -C "" -f id_ed25519
+	raw := []byte("-----BEGIN OPENSSH PRIVATE KEY-----\n" +
+		"b3BlbnNzaC1rZXktdjEAAAAAHWNoYWNoYTIwLXBvbHkxMzA1QG9wZW5zc2guY29tAAAABm\n" +
+		"JjcnlwdAAAABgAAAAQm7/o2GzGJpuJLhCPlLU/sQAAABgAAAABAAAAMwAAAAtzc2gtZWQy\n" +
+		"NTUxOQAAACA4QVdzvb4HCqCZj4tXu7S0hIboW57NfXUcX07lYAeYOgAAAIjMByPI6RD6cK\n" +
+		"8Nonbb0y4H0T2nX3wE9BvtUSkXGHD4W3SuYTGVSLHAS+2JUFriSzhSFbQTQUpTb2OlYSr1\n" +
+		"/rJ9hLF35XVa2nt0DGD8IIA3muW2Dz/mW60ny+nBCUw0YIZ3VEb7EZLEUWZOXL3wOy8BJW\n" +
+		"0lvw8bYXJruIE+ThGcML65RSBi013vs1hBBlFC83KijtS5SVW2Aw==\n" +
+		"-----END OPENSSH PRIVATE KEY-----")
+
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("failed to decode test PEM block")
+	}
+
+	components, err := GenerateCdxComponents(block)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assert.Len(t, components, 4)
+
+	cipher := components[1]
+	assert.Equal(t, "ChaCha20-Poly1305", cipher.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveAE, cipher.CryptoProperties.AlgorithmProperties.Primitive)
+	assert.Equal(t, "512-bit key (two 256-bit ChaCha20 subkeys: payload+MAC, length field), 64-bit sequence-number nonce, 128-bit tag", cipher.CryptoProperties.AlgorithmProperties.ParameterSetIdentifier)
+	if assert.NotNil(t, cipher.CryptoProperties.AlgorithmProperties.CryptoFunctions) {
+		assert.ElementsMatch(t,
+			[]cdx.CryptoFunction{cdx.CryptoFunctionEncrypt, cdx.CryptoFunctionDecrypt, cdx.CryptoFunctionTag},
+			*cipher.CryptoProperties.AlgorithmProperties.CryptoFunctions)
+	}
+
+	pubKey := components[3]
+	assert.Equal(t, "ED25519", pubKey.Name)
+}
+
+// Some tools mislabel a PKCS8 EncryptedPrivateKeyInfo as "PRIVATE KEY" instead of the standard
+// "ENCRYPTED PRIVATE KEY". x509.ParsePKCS8PrivateKey then fails, but the content is still
+// recognizably encrypted PKCS8 (its outer SEQUENCE decodes as AlgorithmIdentifier+OCTET STRING,
+// not the version-INTEGER-first shape of a real PrivateKeyInfo), so it should still be enriched
+// rather than falling back to a generic secret.
+func TestGenerateCdxComponentsMislabeledEncryptedPKCS8Key(t *testing.T) {
+	// Same DER as TestGenerateCdxComponentsPKCS8EncryptedKey, wrapped in a "PRIVATE KEY" label.
+	raw := []byte("-----BEGIN PRIVATE KEY-----\n" +
+		"MIIFNTBfBgkqhkiG9w0BBQ0wUjAxBgkqhkiG9w0BBQwwJAQQpSWo8bNANk2fHXl2\n" +
+		"PVxCsAICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEGJ+KfImD/Z6emMe\n" +
+		"gVedeoUEggTQkG2fi3wPe9kHM1EyWlnu/sTu6fh/h3fYHQXTD7NFG3QZaQDsyfbO\n" +
+		"PEl0G6zxMLb1LcEcPNHy6dO9CbzaBtlsQKUCtj8CiCzjjRB8mUEjq4zwT4+yfEP1\n" +
+		"Djd0P7Eb4LF7sOINwA9KTQEL4lBYKddjSB9XD2mfHWNqNxQK4aF7cfRj81NDhi9G\n" +
+		"NIhdrGbMXCWAUn3bd0ARwf05/yiOIWtmr6VjnC2KOjngbx4eXRHBkxtI9YnY31/I\n" +
+		"M4nJWxpbjVI2fNpSf1xJLYszvIKakttWlUyTGvEsFCq4NUvLdPSGx4ITtotD2GHj\n" +
+		"AQctLYP/3I6SM1P+mKsEaSEgVpJ0gkLPzwDZS23YRgp6DQxqW0rNk+seqzmDF5o+\n" +
+		"Do2Eu2HhpRHB3lXOZ8KZzC3X6UJzMtYeEq74iRFSs3hwxXHpEJJpKOL9o5l+0eQ7\n" +
+		"RnjI05x74RKTo4+8xo4b+9VttSfh7+zbPCLxJ6oiom/mJiATIr4RB2Uu2KmziOGs\n" +
+		"WwtvDe8So4SDaH/n/ryGzZ3XTFlwjCM7qGWIbK5RkasMGd/NsJ7zaj7fB9BO2E92\n" +
+		"pkjsVnjVIYk1RwOWTb2bcxt5j6qRtNwhnSFQlP7OdrsY2gpT0fhaPkX3c+ben9pN\n" +
+		"29VU+62e02gXuVnQHgfm7RefGWRVPin57dpYfI9xTfQmyJeyTtngDLqLtYcOEe3p\n" +
+		"8Eplict39vt59465CxhdeTZhq4/jyPNIXdw1hM4gNHT36j3orbdjK8zWeAEEgaGd\n" +
+		"RRCJOdrCgQPbK7/VHkc0JGxaLbFDqSp0bH6Iz5Zcyf1agGcWqjFcESr/RiePM7Cg\n" +
+		"kPQGr64PCJ2BTEZH58WOIgXID0sKZp+qkjC9UDpkxbeFIMxRGZJflAiqopD7mO3S\n" +
+		"xu/VXvxkhkUp+skBLI8B5rlI2PUvj68BQW2zJ8o/iKT9L0lf18teszhyo0V00stY\n" +
+		"nA/6h9UVEKY5NA9DvksiZP4dUbDlsXcNefi6PK8SRtI7oX0LZFgft5DlAN5MAW/q\n" +
+		"6psPYB++imvuV7f65wmr8uWFBWqgii/7oPUPhmrf+tW7jTAzafyZLBUMCeGyp25O\n" +
+		"p12y1V3Ec/wlSZ/+T0bsEwR6tycI55GzLx9DEMdtVjwK2YsxV9cIqbiBmdTJ5AH2\n" +
+		"zZqyTnIlyIyun1fntRvn/+O87DGytMGZWEv+1XbGdne8c2xZJK5ltqQKLph2qsoM\n" +
+		"8EbJhReVxZ9jkCRkNCdspCvY1bELVHU/VFhPSSJTbO4C0hYNvzPxQQYsh9tXZioF\n" +
+		"TXvlPMVsbHRJdOAgseUNI2x5/ZRou4DWcklorWR7bXUJC4IUS9zlRnkyfSy0kLMi\n" +
+		"ku4OBOAxCvwXzx9E/qL3LPz5mODisv5SNSSTWcYGCDiRH3sZ8e6nEsHB0deBndx8\n" +
+		"uEQ7Xk/a3jNFeNq9PIH1zf9xx+YEd0UesuhXWaNR2oDbaI7vU97uINmW1UsOOh3p\n" +
+		"ldR3U1KkccxFjgETr0Yh4EzxP1ulcuLE2n444Wlg55POOocILofgZdOlpPC1WLpI\n" +
+		"HflB1TXRe8oRTYqmBUWe3/1A7ovx76aVKZo1sqkHAkC2lp4MaV+V+UaHVeVUDqW3\n" +
+		"pqcP4PIRXJ/RQowYxrggwnIlPvsbB+xi1rMA7x4MxH+7XMiprxJvxiw=\n" +
+		"-----END PRIVATE KEY-----")
+
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("failed to decode test PEM block")
+	}
+	assert.Equal(t, "PRIVATE KEY", block.Type)
+
+	components, err := GenerateCdxComponents(block)
+	if err != nil {
+		t.Fatalf("expected no error for a mislabeled encrypted key, got: %v", err)
+	}
+	assert.Len(t, components, 3)
+	assert.Equal(t, cdx.CryptoAssetTypeRelatedCryptoMaterial, components[0].CryptoProperties.AssetType)
+	assert.Equal(t, cdx.RelatedCryptoMaterialTypePrivateKey, components[0].CryptoProperties.RelatedCryptoMaterialProperties.Type)
+}
+
+// A "PRIVATE KEY" block that is neither a valid PrivateKeyInfo nor shaped like an
+// EncryptedPrivateKeyInfo is genuinely malformed, not encrypted, and must still surface as an
+// error rather than being misidentified as an encrypted key.
+func TestGenerateCdxComponentsUnencryptedMalformedPKCS8KeyStillErrors(t *testing.T) {
+	raw := []byte("-----BEGIN PRIVATE KEY-----\n" +
+		"MAA=\n" +
+		"-----END PRIVATE KEY-----")
 
 	block, _ := pem.Decode(raw)
 	if block == nil {

--- a/scanner/pem/pem_test.go
+++ b/scanner/pem/pem_test.go
@@ -1,0 +1,236 @@
+// Copyright 2024 PQCA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pem
+
+import (
+	"encoding/pem"
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateCdxComponentsLegacyEncryptedRSAKey(t *testing.T) {
+	raw := []byte("-----BEGIN RSA PRIVATE KEY-----\n" +
+		"Proc-Type: 4,ENCRYPTED\n" +
+		"DEK-Info: DES-EDE3-CBC,BA26229A1653B7FF\n\n" +
+		"2i5PgUsjTMVjyLog9C0BgFyMOBAujM3zwSAr4W2vsIjMHY2Rm4gtLQ0hIhc8dGWH\n" +
+		"-----END RSA PRIVATE KEY-----")
+
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("failed to decode test PEM block")
+	}
+
+	components, err := GenerateCdxComponents(block)
+	if err != nil {
+		t.Fatalf("expected no error for a recognized encrypted key, got: %v", err)
+	}
+	assert.Len(t, components, 2)
+
+	props := components[0].CryptoProperties.RelatedCryptoMaterialProperties
+	assert.Equal(t, cdx.RelatedCryptoMaterialTypePrivateKey, props.Type)
+	assert.NotNil(t, props.SecuredBy)
+	assert.Equal(t, "Software", props.SecuredBy.Mechanism)
+	assert.Equal(t, cdx.BOMReference(components[1].BOMRef), props.SecuredBy.AlgorithmRef)
+
+	cipher := components[1]
+	assert.Equal(t, "DES-EDE3-CBC", cipher.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveBlockCipher, cipher.CryptoProperties.AlgorithmProperties.Primitive)
+	assert.Equal(t, cdx.CryptoAlgorithmModeCBC, cipher.CryptoProperties.AlgorithmProperties.Mode)
+}
+
+func TestGenerateCdxComponentsPKCS8EncryptedKey(t *testing.T) {
+	// EncryptedPrivateKeyInfo using PBES2 with PBKDF2 and aes-256-CBC-PAD, generated via
+	// `openssl genpkey -algorithm RSA | openssl pkcs8 -topk8 -v2 aes-256-cbc`.
+	raw := []byte("-----BEGIN ENCRYPTED PRIVATE KEY-----\n" +
+		"MIIFNTBfBgkqhkiG9w0BBQ0wUjAxBgkqhkiG9w0BBQwwJAQQpSWo8bNANk2fHXl2\n" +
+		"PVxCsAICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEGJ+KfImD/Z6emMe\n" +
+		"gVedeoUEggTQkG2fi3wPe9kHM1EyWlnu/sTu6fh/h3fYHQXTD7NFG3QZaQDsyfbO\n" +
+		"PEl0G6zxMLb1LcEcPNHy6dO9CbzaBtlsQKUCtj8CiCzjjRB8mUEjq4zwT4+yfEP1\n" +
+		"Djd0P7Eb4LF7sOINwA9KTQEL4lBYKddjSB9XD2mfHWNqNxQK4aF7cfRj81NDhi9G\n" +
+		"NIhdrGbMXCWAUn3bd0ARwf05/yiOIWtmr6VjnC2KOjngbx4eXRHBkxtI9YnY31/I\n" +
+		"M4nJWxpbjVI2fNpSf1xJLYszvIKakttWlUyTGvEsFCq4NUvLdPSGx4ITtotD2GHj\n" +
+		"AQctLYP/3I6SM1P+mKsEaSEgVpJ0gkLPzwDZS23YRgp6DQxqW0rNk+seqzmDF5o+\n" +
+		"Do2Eu2HhpRHB3lXOZ8KZzC3X6UJzMtYeEq74iRFSs3hwxXHpEJJpKOL9o5l+0eQ7\n" +
+		"RnjI05x74RKTo4+8xo4b+9VttSfh7+zbPCLxJ6oiom/mJiATIr4RB2Uu2KmziOGs\n" +
+		"WwtvDe8So4SDaH/n/ryGzZ3XTFlwjCM7qGWIbK5RkasMGd/NsJ7zaj7fB9BO2E92\n" +
+		"pkjsVnjVIYk1RwOWTb2bcxt5j6qRtNwhnSFQlP7OdrsY2gpT0fhaPkX3c+ben9pN\n" +
+		"29VU+62e02gXuVnQHgfm7RefGWRVPin57dpYfI9xTfQmyJeyTtngDLqLtYcOEe3p\n" +
+		"8Eplict39vt59465CxhdeTZhq4/jyPNIXdw1hM4gNHT36j3orbdjK8zWeAEEgaGd\n" +
+		"RRCJOdrCgQPbK7/VHkc0JGxaLbFDqSp0bH6Iz5Zcyf1agGcWqjFcESr/RiePM7Cg\n" +
+		"kPQGr64PCJ2BTEZH58WOIgXID0sKZp+qkjC9UDpkxbeFIMxRGZJflAiqopD7mO3S\n" +
+		"xu/VXvxkhkUp+skBLI8B5rlI2PUvj68BQW2zJ8o/iKT9L0lf18teszhyo0V00stY\n" +
+		"nA/6h9UVEKY5NA9DvksiZP4dUbDlsXcNefi6PK8SRtI7oX0LZFgft5DlAN5MAW/q\n" +
+		"6psPYB++imvuV7f65wmr8uWFBWqgii/7oPUPhmrf+tW7jTAzafyZLBUMCeGyp25O\n" +
+		"p12y1V3Ec/wlSZ/+T0bsEwR6tycI55GzLx9DEMdtVjwK2YsxV9cIqbiBmdTJ5AH2\n" +
+		"zZqyTnIlyIyun1fntRvn/+O87DGytMGZWEv+1XbGdne8c2xZJK5ltqQKLph2qsoM\n" +
+		"8EbJhReVxZ9jkCRkNCdspCvY1bELVHU/VFhPSSJTbO4C0hYNvzPxQQYsh9tXZioF\n" +
+		"TXvlPMVsbHRJdOAgseUNI2x5/ZRou4DWcklorWR7bXUJC4IUS9zlRnkyfSy0kLMi\n" +
+		"ku4OBOAxCvwXzx9E/qL3LPz5mODisv5SNSSTWcYGCDiRH3sZ8e6nEsHB0deBndx8\n" +
+		"uEQ7Xk/a3jNFeNq9PIH1zf9xx+YEd0UesuhXWaNR2oDbaI7vU97uINmW1UsOOh3p\n" +
+		"ldR3U1KkccxFjgETr0Yh4EzxP1ulcuLE2n444Wlg55POOocILofgZdOlpPC1WLpI\n" +
+		"HflB1TXRe8oRTYqmBUWe3/1A7ovx76aVKZo1sqkHAkC2lp4MaV+V+UaHVeVUDqW3\n" +
+		"pqcP4PIRXJ/RQowYxrggwnIlPvsbB+xi1rMA7x4MxH+7XMiprxJvxiw=\n" +
+		"-----END ENCRYPTED PRIVATE KEY-----")
+
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("failed to decode test PEM block")
+	}
+
+	components, err := GenerateCdxComponents(block)
+	if err != nil {
+		t.Fatalf("expected no error for a recognized encrypted key, got: %v", err)
+	}
+	assert.Len(t, components, 3)
+
+	props := components[0].CryptoProperties.RelatedCryptoMaterialProperties
+	assert.Equal(t, cdx.RelatedCryptoMaterialTypePrivateKey, props.Type)
+	assert.NotNil(t, props.SecuredBy)
+	assert.Equal(t, "Software", props.SecuredBy.Mechanism)
+	assert.Equal(t, cdx.BOMReference(components[1].BOMRef), props.SecuredBy.AlgorithmRef)
+
+	cipher := components[1]
+	assert.Equal(t, "AES-256-CBC", cipher.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveBlockCipher, cipher.CryptoProperties.AlgorithmProperties.Primitive)
+	assert.Equal(t, cdx.CryptoAlgorithmModeCBC, cipher.CryptoProperties.AlgorithmProperties.Mode)
+
+	kdf := components[2]
+	assert.Equal(t, "PBKDF2-HMAC-SHA256", kdf.Name)
+	assert.Equal(t, cdx.CryptoPrimitiveKDF, kdf.CryptoProperties.AlgorithmProperties.Primitive)
+}
+
+func TestGenerateCdxComponentsPKCS8EncryptedKeyOmittedPRFDefaultsToSHA1(t *testing.T) {
+	// PBKDF2-params generated with `openssl pkcs8 -topk8 -v2 aes-256-cbc -v2prf hmacWithSHA1`.
+	// OpenSSL omits the prf field entirely here since HMAC-SHA1 is the RFC 8018 default,
+	// so this exercises the fallback rather than an explicit HMAC-SHA1 AlgorithmIdentifier.
+	raw := []byte("-----BEGIN ENCRYPTED PRIVATE KEY-----\n" +
+		"MIIFJzBRBgkqhkiG9w0BBQ0wRDAjBgkqhkiG9w0BBQwwFgQQre5HmYmLBhc8S/7I\n" +
+		"9arQsgICCAAwHQYJYIZIAWUDBAEqBBDScJ/U2h4vdioLThjCKI5rBIIE0JwPnWOI\n" +
+		"NcD1LGwji659l5x9v8lDVnm/vVXb/+LO/IjcLVvYL2ICKmO7Tw1RhKC1Gwcbzcw/\n" +
+		"rCXfT2BA3H/enWTR9vnEmDpMS3Ux8m3C19F7MswXqbjXQTtDAPBAwd2ZI/Wgd8fu\n" +
+		"myRqWH+mII7Y/RWviyBz9v8k58iU7j3ITgjvtjtCDHPoxexKkP4WMKf/MvNJ+Z5R\n" +
+		"QHxLFIe0oxd2nT8BAX23BVGIW9sfgJH0I0rIxD+8UUirSUSXOhZOj7Hqovbof/hk\n" +
+		"QNxMkdfipJx8FkoTr4fDumuf2NC/mMC1mwPDIIlKirTSeYvAxFKeLoNPD43L0kIm\n" +
+		"zwdCejqat5iuKHiXGaYmMWCcdBJ82y6K5HzM/UBNimWtZPEVcvvmSDfMKckw/65r\n" +
+		"1x2hibtY2XTicWNvCHOInZTArfXAd1Chniq/kAT2rk+NZ9VxDFxB30Kqx2W0YuJJ\n" +
+		"dns+L2OWv9Ft9OY5SziE4UcSiaGLViIV1O2jb7kTBrgyZ2uD78ZgIVdQLCb2E3Ut\n" +
+		"RRQGGeNtjPqm/SnBpru25+QENFonDKkbQhUQDWVqQSSDT+44CCWckq2N4UxysJ49\n" +
+		"ypgAPmw61taA1RfclWGhuDZBVIPElqeyMnPMyJkkShunlEC16F4eTvFmNVC4P+Hg\n" +
+		"6k3y15kw0Lq6eE66jdKMHkpw6TyFJhiR0acbltkI/duQT6a0DVoZCCbbQU3YeSeU\n" +
+		"fKW8LopWnrY2tIH6Tq5P0rIJrTvvxpI5SM3QPr3uYQzf0JhoAFPjLiL+ZHJww5z5\n" +
+		"klR24hbJGnDq6ja4j/5GH3Bq4SPYAuWkc14Fbvpq347PcsgSLHUfeBk9+fTHLUCG\n" +
+		"wNOIU0f8F1iJCZDIOK4aNT3wNmB13sw1VGtf3khF+8rYIcSu5eYvG4f6R+N3TN0E\n" +
+		"Mu0UbYpCVhNQfoEKk+7vpMLf3Wj51NxzjUgWz3CcTcuKjk9YXKBuW2GrCE0a1j+c\n" +
+		"IHpZzDy669DX16H0eMLndRCRzTgnJhy+abKjV3N1DjFbu7BxI8i56mkSJF35B00t\n" +
+		"p/ig1XU6N5mdqqQMhD6tjUg2vnXtBjPqaICQTUbEDFUjBaf1gAOuZU9TrhjsKQoR\n" +
+		"J7MfeTQCyuyQzT0ccTaB8gR/IMyoSavOtVPuzpM9Mr+ZJr7wqUWlSPTzjiQxn9yT\n" +
+		"dDqe3oYWwDgi5NdFpGBNAqCgyudQ3ceongfho+HFRmRSGpbV09iKOzcsO4zWFVaI\n" +
+		"G/LGeqiDqZSogECcoF4IaQ3u8yiYNxWaLU87M9WDAPT6G398Ul2fdCBBO/q6Q4PF\n" +
+		"J28DHp/uzaFUQNCYcmIfu4IJDQyPdAlZeMLPtSm95SEI5O21AzzyWMIi4vLmO3JB\n" +
+		"dFruCgamnS6cyk5JZ8ckvIQOgez2SYE0oL9yjKt44YHZmCQGpmhoUK0i8jopXCNl\n" +
+		"lLPcWsJ7moL+9uaZv103ouTiajQX8z32zDjUgfhAPOLvva4KWP3VNviscyVnmi4I\n" +
+		"Y3EtlIBXQlCQ1aH8jhlUciotWiy4nWRLSoy2v2xOyRfqQE8FpLf2CT6suR9vdXtb\n" +
+		"3jVHscY0U/BvhTFukhTaN3UY0Wzy01oLNMZUA8Wk3/k+mfZ8JslABqDIhEPraLtk\n" +
+		"l37ov9OYhy40GeI6fFJbfePsU5YSCTb1OMu4\n" +
+		"-----END ENCRYPTED PRIVATE KEY-----")
+
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("failed to decode test PEM block")
+	}
+
+	components, err := GenerateCdxComponents(block)
+	if err != nil {
+		t.Fatalf("expected no error for a recognized encrypted key, got: %v", err)
+	}
+	assert.Len(t, components, 3)
+	props := components[0].CryptoProperties.RelatedCryptoMaterialProperties
+	assert.NotNil(t, props.SecuredBy)
+	assert.Equal(t, "Software", props.SecuredBy.Mechanism)
+	assert.Equal(t, cdx.BOMReference(components[1].BOMRef), props.SecuredBy.AlgorithmRef)
+	assert.Equal(t, "AES-256-CBC", components[1].Name)
+	assert.Equal(t, "PBKDF2-HMAC-SHA1", components[2].Name)
+}
+
+func TestGenerateCdxComponentsPKCS8LegacyDirectPBEScheme(t *testing.T) {
+	// A direct (non-PBES2) legacy PKCS12 PBE scheme, generated with
+	// `openssl pkcs8 -topk8 -v1 PBE-SHA1-3DES`. The mechanism should resolve straight from
+	// the outer AlgorithmIdentifier without attempting to unwrap PBES2-shaped parameters.
+	raw := []byte("-----BEGIN ENCRYPTED PRIVATE KEY-----\n" +
+		"MIIE6jAcBgoqhkiG9w0BDAEDMA4ECHbp5eKBDosLAgIIAASCBMgNBtgzt65+T78J\n" +
+		"BQk67jAalv8xmXFJwU2LlWcRc139OYSsuX9t5d0M7PovI6EUnThn/A/uKTHkuC01\n" +
+		"fep+BG9QaVwQMWMHsfmUv0zhAgjZK42vHdXOWzgqf4lziJcfbdPh7GqGX65qsUv+\n" +
+		"vW/5ObCfwFhtOEawfpBypz3q9l5pgsctPtCK0aaOoMHdE+utjxxs+9ttuW+FzJzC\n" +
+		"QUvH5Ujw/sfLbbI4jY0x7qxwU1U4UBq/n1KZSp67w3sVg9O1nD9Ruh+cnl+7e0ib\n" +
+		"bRh/MuLx5J+eYj9eEdtL1M/UiGcGLDLG7SWxGnTKmdMPcdYyYVCJJS3LGo9WKMcF\n" +
+		"4hTR7snq+3guuNDaqpBtoLyZXGRNoyvM2Uq0t5qfjMVU9HvgKzwXBJ4GSNMObVPQ\n" +
+		"4uNM8hN714tx/HdkblCw/56Uxt3YlGHR6MEXDvUlOPJI1wj8SF3TuIPpn4SMvUky\n" +
+		"M9AKYowIls1pWBD6tMzGCihW0dsHUeGiS/3ctKVTA1uw9U9Tjo1bBfCOlPDJ9vO9\n" +
+		"RUPVN2Ea0wilFtB6I9+pmNrlCju5cfiQK0403v4PQZhwZ87oWIpJgCG48jVISA76\n" +
+		"XyFTcAoZIMadteFslaAe8Ks+DBVOnL4wvl2A9UjYLHLihx3dy1fIiTvvDP27mVDG\n" +
+		"aSm63bl63I+AoBR2+3BCgAZaekIpjKdAO5Ld9VsdhDDV0nxhBZSYH/ioSTW2PCwn\n" +
+		"obpFDatUWER09aYgbHyr2LJQ1EBCMwyEuqmxtq1XBGKStMQjn6CDhVc5ith6S/1J\n" +
+		"tr2LpJQsDbVMXmd84vFJZXJ8Pc7qI9yHZ3S6VK96/K65OxcH4qxX5awXaH4AfTTf\n" +
+		"1WPreDjHlfSw/ivGaRcc31tTYdzyXZu1VjsJDkr+xm46Cox5BlRxPYbi2o7+NbuV\n" +
+		"M4pwk6l4e7lxaEwCw/XG2z0nQoYA/7sJrsF8b11l20X6fVEqRqLxi0SE0PKdIEH5\n" +
+		"TsF70B00W/IumH0aOOoWs4zeoUvyRkwkXSP6j2pGvvNLNOLx6HG1ePyYMQP3lYRZ\n" +
+		"C8c60quVLUMJP0iol9YDNaQMjWMEXXeiLSwvnILNFjY4/6xusVrvqKV6bfpc7DCD\n" +
+		"24GP71Ug7KoTn2GMFq96nmuOyeuW8T0YPEjC/gnt9ZqhPFJzOMfWBqptJX4/tpws\n" +
+		"9P0VVQvQePmKERXrnXeSiauETeLSvnAGmjbvyZMbnasMxAwOe1wssN/9sGPChkv7\n" +
+		"oA0mW7TNUh4vPYYk5QKAIo1gTt3VuZ7++aTmYZcPnJxAE4l/NmKMucZv95xnZSXU\n" +
+		"KomM9RLeHPJPa0wGJ3DoDKduKJHGQqyUdvNihdcwl9jSrAH1Qn8hmpvprEoz+hrk\n" +
+		"wThiGFL6yQeK8+e9kLS0HUQvyUCTv8dmT+C7kc3LHmZG93pHQuT2/0yuJ9/bN4qu\n" +
+		"eWXjpslP8zfozfBk5qv2Nl+pbeYBaG6CAmVcCSyPqBw3ISLGN+OQazHVvY2Yi+bI\n" +
+		"yMrNlOQ3jjaJ+zmBTZqg7w4tAr5mG3D6wjb185egcnf51AJuqJSkvmPeXrDnaH/R\n" +
+		"ehdCdHwWGPCartWe7WqQU1bYWr0B9Duo+Vhu5kVbm9az4qICnWV/SATjVnG8Au9U\n" +
+		"tqmMaSdIspQb9HGd7Cg=\n" +
+		"-----END ENCRYPTED PRIVATE KEY-----")
+
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("failed to decode test PEM block")
+	}
+
+	components, err := GenerateCdxComponents(block)
+	if err != nil {
+		t.Fatalf("expected no error for a recognized encrypted key, got: %v", err)
+	}
+	assert.Len(t, components, 2)
+	props := components[0].CryptoProperties.RelatedCryptoMaterialProperties
+	assert.NotNil(t, props.SecuredBy)
+	assert.Equal(t, "Software", props.SecuredBy.Mechanism)
+	assert.Equal(t, cdx.BOMReference(components[1].BOMRef), props.SecuredBy.AlgorithmRef)
+	assert.Equal(t, "pbeWithSHAAnd3-KeyTripleDES-CBC", components[1].Name)
+}
+
+func TestGenerateCdxComponentsUnencryptedMalformedKeyStillErrors(t *testing.T) {
+	// A block recognized as an RSA private key that fails to parse for reasons other than
+	// encryption (e.g. corrupted key material) must still surface as an error, unchanged.
+	raw := []byte("-----BEGIN RSA PRIVATE KEY-----\n" +
+		"MAA=\n" +
+		"-----END RSA PRIVATE KEY-----")
+
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("failed to decode test PEM block")
+	}
+
+	_, err := GenerateCdxComponents(block)
+	assert.Error(t, err)
+}

--- a/scanner/plugins/secrets/secrets.go
+++ b/scanner/plugins/secrets/secrets.go
@@ -17,9 +17,9 @@
 package secrets
 
 import (
-	"io"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"io"
 	"strings"
 
 	"github.com/cbomkit/cbomkit-theia/provider/filesystem"
@@ -154,6 +154,11 @@ func (finding findingWithMetadata) getPrivateKeyComponent() ([]cdx.Component, er
 	for block := range blocks {
 		currentComponents, err := pem.GenerateCdxComponents(block)
 		if err != nil {
+			// The PEM block is a recognized private-key type (e.g. encrypted, or otherwise
+			// undecodable), but its contents could not be parsed into key material. Still
+			// record it as a generic secret rather than dropping a confirmed finding.
+			log.WithError(err).WithField("path", finding.File).Warn("Found private key PEM block but could not parse its key material; recording as generic secret")
+			components = append(components, finding.getGenericSecretComponent())
 			continue
 		}
 

--- a/scanner/plugins/secrets/secrets_test.go
+++ b/scanner/plugins/secrets/secrets_test.go
@@ -66,3 +66,36 @@ func TestPrivateKey(t *testing.T) {
 	assert.Equal(t, *keyComponent.CryptoProperties.RelatedCryptoMaterialProperties.Size, 2048)
 	assert.Equal(t, keyComponent.CryptoProperties.OID, "1.2.840.113549.1.1.1")
 }
+
+// A PEM block recognized as a private key type whose body cannot be parsed (e.g. because it is
+// password-encrypted) must still be reported as a generic secret rather than dropped entirely.
+func TestEncryptedPrivateKeyFallsBackToGenericSecret(t *testing.T) {
+	detector, err := detect.NewDetectorDefaultConfig()
+	if err != nil {
+		t.Fail()
+		return
+	}
+
+	encryptedPrivateKeyRaw := "-----BEGIN RSA PRIVATE KEY-----\nProc-Type: 4,ENCRYPTED\nDEK-Info: DES-EDE3-CBC,BA26229A1653B7FF\n\n2i5PgUsjTMVjyLog9C0BgFyMOBAujM3zwSAr4W2vsIjMHY2Rm4gtLQ0hIhc8dGWH\nJXOAK67UlwiXwmVfbXqI4G3AZS0i5r+wIugRxjejWFRMEubvsMd5D8vqHmYhoBM+\nOw+PmVwq9pRXQhIWuUBznHevWZeSFHmSjcSlM9BFV2rn3zvS4bMoIU00OoZplVKp\n-----END RSA PRIVATE KEY-----"
+
+	fragment := detect.Fragment{Raw: encryptedPrivateKeyRaw, FilePath: "encrypted-key.pem"}
+	findings := detector.Detect(fragment)
+	assert.Len(t, findings, 1)
+	assert.Equal(t, findings[0].RuleID, "private-key")
+
+	findingWithMeta := findingWithMetadata{
+		Finding: findings[0],
+		raw:     []byte(encryptedPrivateKeyRaw),
+	}
+
+	components, err := findingWithMeta.getComponents()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	// The encrypted-key component, plus a standalone algorithm component for its cipher
+	// referenced via SecuredBy.AlgorithmRef.
+	assert.Len(t, components, 2)
+	assert.Equal(t, components[0].CryptoProperties.AssetType, cdx.CryptoAssetTypeRelatedCryptoMaterial)
+	assert.Equal(t, components[0].CryptoProperties.RelatedCryptoMaterialProperties.Type, cdx.RelatedCryptoMaterialTypePrivateKey)
+}


### PR DESCRIPTION
Encrypted Private Key Detection & SecuredBy Metadata
1. Feature / Problem Statement
 secrets.go's getPrivateKeyComponent() handles every gitleaks-confirmed private-key finding the same way: hand the PEM block to pem.GenerateCdxComponents(), and if that returned an error for any reason, silently continue — dropping the finding from the CBOM entirely.

That error path fires for password-encrypted private keys — x509.ParsePKCS8PrivateKey, x509.ParseECPrivateKey, x509.ParsePKCS1PrivateKey, and ssh.ParseRawPrivateKey all fail on encrypted key bytes, since they expect plaintext key material. The result: a confirmed secret that gitleaks had already flagged could vanish from the CBOM with no trace, purely because it happened to be encrypted rather than corrupted. 

This change delivers two things:

Never drop a confirmed finding. If pem.GenerateCdxComponents still errors for a reason unrelated to encryption (corrupted key material, unrecognized format), the code now falls back to a generic secret component instead of skipping the finding outright.
Distinguish "encrypted" from "corrupted," and describe how it's encrypted. The scanner now positively detects both ways a PEM private key signals encryption — legacy OpenSSL PEM headers, and standard PKCS#8 ENCRYPTED PRIVATE KEY ASN.1 structure — and emits a proper CycloneDX component: RelatedCryptoMaterialProperties.Type = private-key, Format = PEM, and a SecuredBy block whose Mechanism and AlgorithmRef conform to the CBOM spec's own intended shape (a protection category plus a real reference to an algorithm component), rather than a bare opaque secret with zero crypto context.
2. Private Key Standards Over the Years
The reason this needed several distinct code paths rather than one parser is that PEM private key encryption has never had a single standard — it accreted conventions over three decades, and cbomkit-theia has to recognize whichever one a scanned repo happens to contain:

Era	Standard	Encryption representation
1993	PKCS#1 (RSA) / later SEC1 (EC)	No built-in encryption at all — these formats describe only the raw key.
~1995, informal	OpenSSL legacy PEM headers	Bolted on outside any RFC: Proc-Type: 4,ENCRYPTED + DEK-Info: <cipher>,<iv> headers above the base64 body. Key derivation is OpenSSL's own EVP_BytesToKey (effectively a single-round MD5 KDF, no salt beyond the IV) — considered weak today, but still what openssl genrsa -aes256 produces by default, and still common in the wild.
1998–2016	PKCS#5 v1.5 / PKCS#8 (RFC 2898, RFC 5208)	PKCS#8 standardized a generic wrapper for any private key type. Password-based encryption ("PBES1") fuses a specific hash+cipher pair into a single OID (e.g. pbeWithSHA1AndDES-CBC) — no separable KDF/cipher choice.
1999	PKCS#12 Appendix B	A parallel, .p12-oriented set of PBE schemes (pbeWithSHAAnd128BitRC4, etc.), same single-fused-OID shape as PBES1, just a different spec.
2017	PKCS#5 v2.1 / RFC 8018, "PBES2"	The modern, generalized scheme: names its KDF (PBKDF2 or scrypt, RFC 7914) and its cipher (AES-CBC/GCM, etc.) as two independent AlgorithmIdentifiers inside the ASN.1, rather than one fused OID. PBKDF2 itself further allows an optional PRF choice (HMAC-SHA1/256/etc.), defaulting to HMAC-SHA1 when omitted. This is what modern tooling produces by default — e.g. openssl pkcs8 -topk8 -v2 aes-256-cbc.
Because cbomkit-theia scans arbitrary real-world repositories, it has to handle the full span of this history at once — decades-old legacy conventions that are still frequently produced, alongside the current PBES2 standard — which is why the fix branches on scheme rather than assuming one format.

3. The Fix Logic
scanner/plugins/secrets/secrets.go — in getPrivateKeyComponent()'s loop, an error from pem.GenerateCdxComponents no longer continues past the finding. It's logged (log.WithError(err).WithField("path", ...).Warn(...)) and the finding is preserved as a generic secret component, so nothing is silently lost.

scanner/pem/pem.go — block-type dispatch and two encryption-detection paths:

Legacy header encryption (legacyEncryptionComponents): for RSA PRIVATE KEY / EC PRIVATE KEY blocks whose x509 parse fails, checks for Proc-Type: ...ENCRYPTED...; if present, reads the cipher name out of DEK-Info and builds the component pair directly.
PKCS#8 encryption (pkcs8EncryptionComponents, dispatching to three focused helpers):
legacyPBEEncryptionComponents — the non-PBES2, single-fused-OID schemes (PBES1 and PKCS#12 PBE). One OID, one component; cipher and KDF aren't separable.
pbes2EncryptionComponents — unmarshals PBES2-params to recover the keyDerivationFunc and encryptionScheme as independent AlgorithmIdentifiers, and builds a separate algorithm component for each.
pbes2KDFComponent — when the KDF is specifically PBKDF2, unwraps PBKDF2-params to recover the PRF hash and fold it into the component name (e.g. PBKDF2-HMAC-SHA256), defaulting to HMAC-SHA1 per RFC 8018 when the prf field is omitted from the DER (as OpenSSL does when it matches the default).
Component wiring: cipher and KDF get their own cdx.CryptoAssetTypeAlgorithm components (via makeAlgorithmComponent, matching the pattern already used in x509.go/tls.go), each with its own generated BOMRef. The encrypted-key component's SecuredBy.AlgorithmRef points at the cipher component specifically — since CycloneDX's AlgorithmRef is a single reference and PBES2 is a composite of two algorithms, the KDF is included as a second, unlinked component in the same result (the same pattern tls.go already uses for composite cipher suites) rather than trying to conflate both into one reference. SecuredBy.Mechanism is set to "Software" uniformly, matching the CBOM spec's protection-category examples (HSM/TPM/SGX/Software/None) rather than holding free-text algorithm detail.

Diagnostics without leaking internals into the CBOM: each of the three ASN.1 sub-parse failure branches logs the discarded err at Debug level  giving a trail for investigating malformed/non-conformant key data, without putting raw Go error text into CBOM component fields.

Test coverage (pem_test.go, new): legacy header encryption, PBES2 with explicit PBKDF2 PRF, PBES2 with the RFC-8018-default omitted PRF, a legacy direct (non-PBES2) PBE scheme, and confirmation that a genuinely corrupted (non-encrypted) key still surfaces as a real error, unchanged. secrets_test.go updated to expect the enriched 2-component result (key + cipher) instead of a single generic secret for the encrypted-fallback case.